### PR TITLE
Fixing bug when empty string submitted to FormulaGrader

### DIFF
--- a/mitxgraders/formulagrader.py
+++ b/mitxgraders/formulagrader.py
@@ -149,6 +149,10 @@ class FormulaGrader(ItemGrader):
                 # Don't give away the specific string that is being checked for!
                 raise InvalidInput(self.config["forbidden_message"])
 
+        # Check for empty inputs
+        if check == "":
+            return {'ok': False, 'grade_decimal': 0, 'msg': ''}
+
         # Now perform the computations
         try:
             return self.raw_check(answer, student_input)

--- a/mitxgraders/helpers/calc.py
+++ b/mitxgraders/helpers/calc.py
@@ -182,6 +182,10 @@ class ParserCache(object):
 
     def get_parser(self, formula, case_sensitive, suffixes):
         """Get a ParseAugmenter object for a given formula"""
+        # Check for empty formula
+        if formula.strip() == "":
+            return None
+
         # Check the formula for matching parentheses
         count = 0
         delta = {
@@ -246,6 +250,8 @@ def evaluator(formula, variables, functions, suffixes, case_sensitive=True):
 
     # Parse the tree
     math_interpreter = parsercache.get_parser(formula, case_sensitive, suffixes)
+    if math_interpreter is None:
+        return None
 
     # If we're not case sensitive, then lower all variables and functions
     if not case_sensitive:

--- a/tests/test_formulagrader.py
+++ b/tests/test_formulagrader.py
@@ -611,3 +611,8 @@ def test_docs():
     )
     assert grader(None, '2*m')['ok']
     assert not grader(None, '2m')['ok']
+
+def test_empty_input():
+    """Make sure that empty input doesn't crash"""
+    grader = FormulaGrader(answers="1")
+    assert not grader(None, '')['ok']


### PR DESCRIPTION
An empty string now grades as wrong. This addresses issue #9.