### PR TITLE
Fixing bug when empty string submitted to FormulaGrader

### DIFF
--- a/mitxgraders/helpers/calc.py
+++ b/mitxgraders/helpers/calc.py
@@ -238,11 +238,25 @@ def evaluator(formula, variables, functions, suffixes, case_sensitive=True):
     -Variables are passed as a dictionary from string to value. They must be
      python numbers.
     -Unary functions are passed as a dictionary from string to function.
+
+    Usage
+    =====
+    >>> evaluator("1+1", {}, {}, {}, True)
+    (2.0, set([]))
+    >>> evaluator("1+x", {"x": 5}, {}, {}, True)
+    (6.0, set([]))
+    >>> evaluator("square(2)", {}, {"square": lambda x: x*x}, {}, True)
+    (4.0, set(['square']))
+    >>> evaluator("", {}, {}, {}, True)
+    (nan, set([]))
     """
+    if formula is None:
+        # No need to go further.
+        return float('nan'), set()
     formula = formula.strip()
     if formula == "":
         # No need to go further.
-        return float('nan')
+        return float('nan'), set()
 
     # Parse the tree
     math_interpreter = parsercache.get_parser(formula, case_sensitive, suffixes)

--- a/tests/test_formulagrader.py
+++ b/tests/test_formulagrader.py
@@ -611,3 +611,8 @@ def test_docs():
     )
     assert grader(None, '2*m')['ok']
     assert not grader(None, '2m')['ok']
+
+def test_empty_input():
+    """Make sure that empty input doesn't crash"""
+    grader = FormulaGrader(answers="1")
+    assert not grader(None, '')['ok']


### PR DESCRIPTION
An empty string now grades as wrong. This addresses issue #9. Tests fixed too!