### PR TITLE
Reorganize variable name parsing [WIP, do not merge]

### DIFF
--- a/mitxgraders/helpers/calc.py
+++ b/mitxgraders/helpers/calc.py
@@ -23,6 +23,7 @@ from pyparsing import (
     ParseResults,
     Suppress,
     Word,
+    FollowedBy,
     ZeroOrMore,
     alphanums,
     alphas,
@@ -447,20 +448,34 @@ class ParseAugmenter(object):
         # Predefine recursive variables.
         expr = Forward()
 
-        # Handle variables passed in. They must start with a letter
-        # and may contain numbers and underscores afterward.
-        inner_varname = Combine(Word(alphas, alphanums + "_") + ZeroOrMore("'"))
-        # Alternative variable name in tensor format
-        # Tensor name must start with a letter, continue with alphanums
-        # Indices may be alphanumeric
-        # e.g., U_{ijk}^{123}
-        upper_indices = Literal("^{") + Word(alphanums) + Literal("}")
+        # Handle variables passed in. Variables should be of the form
+        #   front + subscripts + lower_indices + upper_indices + tail
+        # where:
+        #   front (required):
+        #       starts with alpha, followed by alphanumeric
+        #   subscripts (optional):
+        #       any combination of alphanumeric and underscores
+        #   lower_indices (optional):
+        #       like subscripts, but with curly braces, e.g., U_{ijk}. Intended
+        #       for consistency with upper-index tensor notation.
+        #   upper_indices (optional):
+        #       e.g., U_{ijk}^{123}
+        #   tail:
+        #       any number of primes
+        front = Word(alphas, alphanums)
+        # ~FollowedBy prevents capturing lower_indices starting character.
+        subscripts = Word(alphanums + '_') + ~FollowedBy('{')
         lower_indices = Literal("_{") + Word(alphanums) + Literal("}")
-        tensor = Combine(Word(alphas, alphanums) + Optional(lower_indices) +
-                         Optional(upper_indices) + ZeroOrMore("'"))
-        # Test for tensor first, then generic variable with underscores for backwards
-        # compatability
-        varname = Group(tensor | inner_varname)("variable")
+        upper_indices = Literal("^{") + Word(alphanums) + Literal("}")
+        tail = ZeroOrMore("'")
+        inner_varname = Combine(
+            front +
+            Optional(subscripts) +
+            Optional(lower_indices) +
+            Optional(upper_indices) +
+            Optional(tail)
+            )
+        varname = Group(inner_varname)("variable")
         varname.setParseAction(self.variable_parse_action)
 
         # Same thing for functions

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -316,3 +316,5 @@ def test_tensors():
     assert evaluator("U_{ijk}^2", {"U_{ijk}":2}, {}, {})[0] == 4
     assert evaluator("U^{ijk}^2", {"U^{ijk}":2}, {}, {})[0] == 4
     assert evaluator("U_{ijk}^{123}^2", {"U_{ijk}^{123}":2}, {}, {})[0] == 4
+    # Regular subscripts still work:
+    assert evaluator("U_cat/2 + T_dog_", {"U_cat":2, "T_dog_":4}, {}, {})[0] == 5


### PR DESCRIPTION
This is a rewrite of the variable name parsing to address #25 

This is a bit more flexible than @jolyonb's original tensor specification. Anything of the form

```
front + subscripts + lower_indices + upper_indices + tail
```
is allowed, where:
- `front` (required): Alphabetical followed by alphanumeric, e.g., `Xab`
- `subscripts` (optional): Alphanumeric and underscores, e.g., `_cd___2_3`
- `lower_indices ` (optional): Like `_{12xy3}`
- `upper_indices ` (optional): Like `^{4abc}`
- `tail ` (optional): Any number of primes.

So for example, `Xab _cd___2_3_{12xy3}^{4abc}` is an allowed variable name.

Using the language above, edX original is `front+start`