### PR TITLE
improve IntegralGrader's handling of complex numbers

### DIFF
--- a/mitxgraders/plugins/integralgrader.py
+++ b/mitxgraders/plugins/integralgrader.py
@@ -72,13 +72,13 @@ class IntegrationError(Exception):
 
 def check_output_is_real(func, error, message):
     """Decorate a function to check that its output is real or raise error with specifed message."""
-    def _func(x):
+    def wrapper(x):
         output = func(x)
         if not isinstance(output, float):
             raise error(message)
         return output
 
-    return _func
+    return wrapper
 
 class IntegralGrader(AbstractGrader):
     """
@@ -422,11 +422,9 @@ class IntegralGrader(AbstractGrader):
             ))
 
             # Check if expressions agree
-            if not within_tolerance(expected_re[0], student_re[0], self.config['tolerance']):
-                num_failures += 1
-                if num_failures > self.config["failable_evals"]:
-                    return {'ok': False, 'grade_decimal': 0, 'msg': ''}
-            if self.config['complex_integrand'] and not within_tolerance(expected_im[0], student_im[0], self.config['tolerance']):
+            expected = expected_re[0] + (expected_im[0] or 0)*1j
+            student = student_re[0] + (student_im[0] or 0)*1j
+            if not within_tolerance(expected, student, self.config['tolerance']):
                 num_failures += 1
                 if num_failures > self.config["failable_evals"]:
                     return {'ok': False, 'grade_decimal': 0, 'msg': ''}

--- a/mitxgraders/plugins/integralgrader.py
+++ b/mitxgraders/plugins/integralgrader.py
@@ -6,6 +6,7 @@ and upper limits, and integration variable, and an integrand.
 """
 
 from __future__ import division
+from functools import wraps
 from numbers import Number
 from scipy import integrate
 from numpy import real, imag
@@ -72,6 +73,8 @@ class IntegrationError(Exception):
 
 def check_output_is_real(func, error, message):
     """Decorate a function to check that its output is real or raise error with specifed message."""
+
+    @wraps(func)
     def wrapper(x):
         output = func(x)
         if not isinstance(output, float):

--- a/mitxgraders/plugins/integralgrader.py
+++ b/mitxgraders/plugins/integralgrader.py
@@ -7,6 +7,8 @@ and upper limits, and integration variable, and an integrand.
 
 from __future__ import division
 from numbers import Number
+from scipy import integrate
+from numpy import real, imag
 from mitxgraders.sampling import (VariableSamplingSet, FunctionSamplingSet, RealInterval,
                                   DiscreteSet, gen_symbols_samples, construct_functions,
                                   construct_constants)
@@ -16,7 +18,6 @@ from mitxgraders.helpers.calc import (CalcError, evaluator)
 from mitxgraders.helpers.validatorfuncs import (Positive, NonNegative,
                                                 PercentageString, is_callable)
 from mitxgraders.helpers.mathfunc import within_tolerance
-from scipy import integrate
 
 __all__ = ["IntegralGrader"]
 
@@ -68,6 +69,16 @@ def transform_list_to_dict(thelist, thedefaults, key_to_index_map):
 class IntegrationError(Exception):
     """Represents an error associated with integration"""
     pass
+
+def check_output_is_real(func, error, message):
+    """Decorate a function to check that its output is real or raise error with specifed message."""
+    def _func(x):
+        output = func(x)
+        if not isinstance(output, float):
+            raise error(message)
+        return output
+
+    return _func
 
 class IntegralGrader(AbstractGrader):
     """
@@ -177,6 +188,7 @@ class IntegralGrader(AbstractGrader):
                 Required('full_output', default=1): 1,
                 Extra: object
             },
+            Required('complex_integrand', default=False): bool,
             # Most of the below are copied from FormulaGrader
             Required('user_functions', default={}):
                 {Extra: Any(is_callable, [is_callable], FunctionSamplingSet)},
@@ -193,20 +205,28 @@ class IntegralGrader(AbstractGrader):
 
     debug_appendix_template = (
         "\n"
-        "Integration Data for Sample Number {samplenum}\n"
-        "Variables: {variables}\n"
         "==============================================\n"
-        "Student Integration Data\n"
-        "=============================================\n"
-        "Numerical Value: {student_eval}\n"
-        "Error Estimate: {student_error}\n"
-        "Number of integrand evaluations: {student_neval}\n"
-        "\n\n"
-        "Author Integration Data\n"
-        "=============================================\n"
-        "Numerical Value: {author_eval}\n"
-        "Error Estimate: {author_error}\n"
-        "Number of integrand evaluations: {author_neval}\n"
+        "Integration Data for Sample Number {samplenum}\n"
+        "==============================================\n"
+        "Variables: {variables}\n"
+        "\n"
+        "========== Student Integration Data, Real Part\n"
+        "Numerical Value: {student_re_eval}\n"
+        "Error Estimate: {student_re_error}\n"
+        "Number of integrand evaluations: {student_re_neval}\n"
+        "========== Student Integration Data, Imaginary Part\n"
+        "Numerical Value: {student_im_eval}\n"
+        "Error Estimate: {student_im_error}\n"
+        "Number of integrand evaluations: {student_im_neval}\n"
+        "\n"
+        "========== Author Integration Data, Real Part\n"
+        "Numerical Value: {author_re_eval}\n"
+        "Error Estimate: {author_re_error}\n"
+        "Number of integrand evaluations: {author_re_neval}\n"
+        "========== Author Integration Data, Imaginary Part\n"
+        "Numerical Value: {author_im_eval}\n"
+        "Error Estimate: {author_im_error}\n"
+        "Number of integrand evaluations: {author_im_neval}\n"
         ""
     )
 
@@ -338,42 +358,67 @@ class IntegralGrader(AbstractGrader):
             funcscope.update(func_samples[i])
             varscope.update(var_samples[i])
 
-            expected = self.evaluate_int(answer['integrand'],
-                                         answer['lower'],
-                                         answer['upper'],
-                                         answer['integration_variable'],
-                                         varscope=varscope,
-                                         funcscope=funcscope)
+            # Evaluate integrals. Error handling here is in two parts because
+            # 1. custom error messages we've added
+            # 2. scipy's warnings re-raised as error messages
+            try:
+                expected_re, expected_im = self.evaluate_int(
+                    answer['integrand'],
+                    answer['lower'],
+                    answer['upper'],
+                    answer['integration_variable'],
+                    varscope=varscope,
+                    funcscope=funcscope
+                )
+            except IntegrationError as e:
+                msg = "Integration Error with author's stored answer: {}"
+                raise ConfigError(msg.format(e.message))
 
-            student = self.evaluate_int(cleaned_input['integrand'],
-                                        cleaned_input['lower'],
-                                        cleaned_input['upper'],
-                                        cleaned_input['integration_variable'],
-                                        varscope=varscope,
-                                        funcscope=funcscope)
+            student_re, student_im = self.evaluate_int(
+                cleaned_input['integrand'],
+                cleaned_input['lower'],
+                cleaned_input['upper'],
+                cleaned_input['integration_variable'],
+                varscope=varscope,
+                funcscope=funcscope
+                )
 
             # scipy raises integration warnings when things go wrong,
             # except they aren't really warnings, they're just printed to stdout
             # so we use quad's full_output option to catch the messages, and then raise errors.
             # The 4th component only exists when its warning message is non-empty
-            if len(student) == 4:
-                raise IntegrationError(student[3])
-            if len(expected) == 4:
-                raise ConfigError(expected[3])
+            if len(student_re) == 4:
+                raise IntegrationError(student_re[3])
+            if len(expected_re) == 4:
+                raise ConfigError(expected_re[3])
+            if len(student_im) == 4:
+                raise IntegrationError(student_im[3])
+            if len(expected_im) == 4:
+                raise ConfigError(expected_im[3])
 
             self.log(self.debug_appendix_template.format(
                 samplenum=i,
                 variables=varscope,
-                student_eval=student[0],
-                student_error=student[1],
-                student_neval=student[2]['neval'],
-                author_eval=expected[0],
-                author_error=expected[1],
-                author_neval=expected[2]['neval'],
+                student_re_eval=student_re[0],
+                student_re_error=student_re[1],
+                student_re_neval=student_re[2]['neval'],
+                student_im_eval=student_im[0],
+                student_im_error=student_im[1],
+                student_im_neval=student_im[2]['neval'],
+                author_re_eval=expected_re[0],
+                author_re_error=expected_re[1],
+                author_re_neval=expected_re[2]['neval'],
+                author_im_eval=expected_im[0],
+                author_im_error=expected_im[1],
+                author_im_neval=expected_im[2]['neval'],
             ))
 
             # Check if expressions agree
-            if not within_tolerance(expected[0], student[0], self.config['tolerance']):
+            if not within_tolerance(expected_re[0], student_re[0], self.config['tolerance']):
+                num_failures += 1
+                if num_failures > self.config["failable_evals"]:
+                    return {'ok': False, 'grade_decimal': 0, 'msg': ''}
+            if self.config['complex_integrand'] and not within_tolerance(expected_im[0], student_im[0], self.config['tolerance']):
                 num_failures += 1
                 if num_failures > self.config["failable_evals"]:
                     return {'ok': False, 'grade_decimal': 0, 'msg': ''}
@@ -401,13 +446,16 @@ class IntegralGrader(AbstractGrader):
                              functions=funcscope,
                              suffixes={})
 
+        if isinstance(lower, complex) or isinstance(upper, complex):
+            raise IntegrationError('Integration limits must be real but have evaluated to complex numbers.')
+
         # It is possible that the integration variable might appear in the limits.
         # Some consider this bad practice, but many students do it and Mathematica allows it.
         # We're going to edit the varscope below to contain the integration variable.
         # Let's store the integration variable's initial value in case it has one.
         int_var_initial = varscope[integration_var] if integration_var in varscope else None
 
-        def integrand(x):
+        def raw_integrand(x):
             varscope[integration_var] = x
             value, _ = evaluator(integrand_str,
                                  case_sensitive=self.config['case_sensitive'],
@@ -416,10 +464,19 @@ class IntegralGrader(AbstractGrader):
                                  suffixes={})
             return value
 
-        result = integrate.quad(integrand, lower, upper, **self.config['integrator_options'])
+        if self.config['complex_integrand']:
+            integrand_re = lambda x: real(raw_integrand(x))
+            integrand_im = lambda x: imag(raw_integrand(x))
+            result_re = integrate.quad(integrand_re, lower, upper, **self.config['integrator_options'])
+            result_im = integrate.quad(integrand_im, lower, upper, **self.config['integrator_options'])
+        else:
+            errmsg = "Integrand has evaluated to complex number but must evaluate to a real."
+            integrand = check_output_is_real(raw_integrand, IntegrationError, errmsg)
+            result_re = integrate.quad(integrand, lower, upper, **self.config['integrator_options'])
+            result_im = (None, None, {'neval':None})
 
         # Restore the integration variable's initial value now that we are done integrating
         if int_var_initial is not None:
             varscope[integration_var] = int_var_initial
 
-        return result
+        return result_re, result_im

--- a/mitxgraders/plugins/integralgrader.py
+++ b/mitxgraders/plugins/integralgrader.py
@@ -85,7 +85,7 @@ class IntegralGrader(AbstractGrader):
     Grades a student-entered integral by comparing numerically with
     an author-specified integral.
 
-    WARNING
+    WARNINGS
     =======
     This grader numerically evaluates the student- and instructor-specified
     integrals using scipy.integrate.quad. This quadrature-based integration
@@ -101,10 +101,18 @@ class IntegralGrader(AbstractGrader):
     In some cases, problems might be avoided by using the integrator_options
     configuration key to provide extra instructions to scipy.integrate.quad.
 
+    Additionally, take care that the integration limits are real-valued.
+    For example, if sqrt(1-a^2) is an integration limit, the sampling range
+    for variable 'a' must gaurantee that the limit sqrt(1-a^2) is real. By
+    default, variables sample from the real interval [1,3].
+
     Configuration Options
     =====================
         answers (dict, required): Specifies author's answer. Has required keys lower,
             upper, integrand, integration_variable, which each take string values.
+
+        complex_integrand (bool): Specifies whether the integrand is allowed to
+            be complex-valued. Defaults to False.
 
         input_positions (dict): Specifies which integration parameters the student
             is required to enter. The default value of input_positions is:

--- a/tests/plugins/test_integralgrader.py
+++ b/tests/plugins/test_integralgrader.py
@@ -113,7 +113,7 @@ def test_empty_input_raises_error():
     with raises(InvalidInput, match=msg):
         grader(None, student_input)
 
-# Integral Evaluation successful tests
+# Integral Evaluation tests
 def test_quadratic_integral_finite():
     grader = IntegralGrader(
         answers={
@@ -170,6 +170,24 @@ def test_convergent_improper_integral_on_finite_domain_with_poles():
     assert grader(None, student_input0) == expected_result
     assert grader(None, student_input1) == expected_result
 
+def test_wrong_answer():
+    grader = IntegralGrader(
+        answers={
+            'lower': 'a',
+            'upper': 'b',
+            'integrand': 'x^2',
+            'integration_variable': 'x'
+        },
+        input_positions={
+            'integrand': 1,
+            'lower': 2,
+            'upper': 3
+        },
+        variables=['a', 'b']
+    )
+    student_input = ['x', '2', '3']
+    expect = {'grade_decimal': 0, 'msg': '', 'ok': False}
+    assert grader(None, student_input) == expect
 
 def test_author_provided_integration_variable():
     grader = IntegralGrader(
@@ -270,6 +288,91 @@ def test_divergent_integral_config_raises_error():
         student_input = ['-1', '1', 'x^2', 'x']
         grader(None, student_input)
 
+def test_author_has_complex_limits_raises_ConfigError():
+    with raises(ConfigError,
+                match=(
+                    "Integration Error with author's stored answer: "
+                    "Integration limits must be real but have evaluated to complex numbers."
+                    )
+               ):
+        grader = IntegralGrader(
+            answers={
+                'lower': '0',
+                'upper': 'sqrt(1-a^2)',
+                'integrand': 'x',
+                'integration_variable': 'x'
+            },
+            variables=['a'],
+            sample_from={
+                'a': [2, 4]
+            }
+        )
+        student_input = ['0', '1', 'x^2', 'x']
+        grader(None, student_input)
+
+def test_student_has_complex_limits_raises_IntegrationError():
+    with raises(IntegrationError,
+                match=(
+                    "There appears to be an error "
+                    "with the integral you entered: Integration limits "
+                    "must be real but have evaluated to complex numbers."
+                    )
+               ):
+        grader = IntegralGrader(
+            answers={
+                'lower': '0',
+                'upper': 'a',
+                'integrand': 'x',
+                'integration_variable': 'x'
+            },
+            variables=['a'],
+            sample_from={
+                'a': [2, 4]
+            }
+        )
+        student_input = ['0', 'sqrt(1-a^2)', 'x^2', 'x']
+        grader(None, student_input)
+
+def test_athor_has_complex_integrand_raises_ConfigError():
+    with raises(ConfigError, match="Integration Error with author's stored answer: Integrand"):
+        grader = IntegralGrader(
+            answers={
+                'lower': '0',
+                'upper': '1',
+                'integrand': 'x+sqrt(-x)',
+                'integration_variable': 'x'
+            },
+            variables=['a'],
+            sample_from={
+                'a': [2, 4]
+            }
+        )
+        student_input = ['0', '1', 'x^2', 'x']
+        grader(None, student_input)
+
+def test_student_has_complex_integrand_raises_IntegrationError():
+    with raises(IntegrationError,
+                match=(
+                    "There appears to be an error "
+                    "with the integral you entered: Integrand has evaluated "
+                    "to complex number but must evaluate to a real."
+                    )
+               ):
+        grader = IntegralGrader(
+            answers={
+                'lower': '0',
+                'upper': '1',
+                'integrand': 'x',
+                'integration_variable': 'x'
+            },
+            variables=['a'],
+            sample_from={
+                'a': [2, 4]
+            }
+        )
+        student_input = ['0', '1', 'x+sqrt(-x)', 'x']
+        grader(None, student_input)
+
 # Debug Test
 def test_debug_message():
     grader = IntegralGrader(
@@ -284,50 +387,113 @@ def test_debug_message():
     )
     student_input = ['1', '8', 'sin(x)', 'x']
     expected_message = (
-        "<pre>"
-        "MITx Grading Library Version VERSION\n"
-        "Student Responses:\n"
-        "1\n"
-        "8\n"
-        "sin(x)\n"
-        "x\n"
-        "\n"
-        "Integration Data for Sample Number 0\n"
-        "Variables: {'infty': inf, 'e': 2.718281828459045, 'i': 1j, 'j': 1j, 's': 5.530375019455111, 'x': 5.530375019455111, 'pi': 3.141592653589793}\n"
-        "==============================================\n"
-        "Student Integration Data\n"
-        "=============================================\n"
-        "Numerical Value: 0.685802339677\n"
-        "Error Estimate: 5.23517337969e-14\n"
-        "Number of integrand evaluations: 21\n"
-        "\n"
-        "\n"
-        "Author Integration Data\n"
-        "=============================================\n"
-        "Numerical Value: 0.685802339677\n"
-        "Error Estimate: 5.23517337969e-14\n"
-        "Number of integrand evaluations: 21\n"
-        "\n"
-        "\n"
-        "Integration Data for Sample Number 1\n"
-        "Variables: {'infty': inf, 'e': 2.718281828459045, 'i': 1j, 'j': 1j, 's': 5.530375019455111, 'x': 5.530375019455111, 'pi': 3.141592653589793}\n"
-        "==============================================\n"
-        "Student Integration Data\n"
-        "=============================================\n"
-        "Numerical Value: 0.685802339677\n"
-        "Error Estimate: 5.23517337969e-14\n"
-        "Number of integrand evaluations: 21\n"
-        "\n"
-        "\n"
-        "Author Integration Data\n"
-        "=============================================\n"
-        "Numerical Value: 0.685802339677\n"
-        "Error Estimate: 5.23517337969e-14\n"
-        "Number of integrand evaluations: 21\n"
+        "<pre>MITx Grading Library Version 1.0.3<br/>\n"
+        "Student Responses:<br/>\n"
+        "1<br/>\n"
+        "8<br/>\n"
+        "sin(x)<br/>\n"
+        "x<br/>\n"
+        "<br/>\n"
+        "==============================================<br/>\n"
+        "Integration Data for Sample Number 0<br/>\n"
+        "==============================================<br/>\n"
+        "Variables: {'infty': inf, 'e': 2.718281828459045, 'i': 1j, 'j': 1j, 's': 5.530375019455111, 'x': 5.530375019455111, 'pi': 3.141592653589793}<br/>\n"
+        "<br/>\n"
+        "========== Student Integration Data, Real Part<br/>\n"
+        "Numerical Value: 0.685802339677<br/>\n"
+        "Error Estimate: 5.23517337969e-14<br/>\n"
+        "Number of integrand evaluations: 21<br/>\n"
+        "========== Student Integration Data, Imaginary Part<br/>\n"
+        "Numerical Value: None<br/>\n"
+        "Error Estimate: None<br/>\n"
+        "Number of integrand evaluations: None<br/>\n"
+        "<br/>\n"
+        "========== Author Integration Data, Real Part<br/>\n"
+        "Numerical Value: 0.685802339677<br/>\n"
+        "Error Estimate: 5.23517337969e-14<br/>\n"
+        "Number of integrand evaluations: 21<br/>\n"
+        "========== Author Integration Data, Imaginary Part<br/>\n"
+        "Numerical Value: None<br/>\n"
+        "Error Estimate: None<br/>\n"
+        "Number of integrand evaluations: None<br/>\n"
+        "<br/>\n"
+        "<br/>\n"
+        "==============================================<br/>\n"
+        "Integration Data for Sample Number 1<br/>\n"
+        "==============================================<br/>\n"
+        "Variables: {'infty': inf, 'e': 2.718281828459045, 'i': 1j, 'j': 1j, 's': 5.530375019455111, 'x': 5.530375019455111, 'pi': 3.141592653589793}<br/>\n"
+        "<br/>\n"
+        "========== Student Integration Data, Real Part<br/>\n"
+        "Numerical Value: 0.685802339677<br/>\n"
+        "Error Estimate: 5.23517337969e-14<br/>\n"
+        "Number of integrand evaluations: 21<br/>\n"
+        "========== Student Integration Data, Imaginary Part<br/>\n"
+        "Numerical Value: None<br/>\n"
+        "Error Estimate: None<br/>\n"
+        "Number of integrand evaluations: None<br/>\n"
+        "<br/>\n"
+        "========== Author Integration Data, Real Part<br/>\n"
+        "Numerical Value: 0.685802339677<br/>\n"
+        "Error Estimate: 5.23517337969e-14<br/>\n"
+        "Number of integrand evaluations: 21<br/>\n"
+        "========== Author Integration Data, Imaginary Part<br/>\n"
+        "Numerical Value: None<br/>\n"
+        "Error Estimate: None<br/>\n"
+        "Number of integrand evaluations: None<br/>\n"
         "</pre>"
-    ).replace("VERSION", __version__).replace("\n", "<br/>\n")
+    ).replace("VERSION", __version__)
     expected_result = {'ok': True, 'grade_decimal': 1, 'msg': expected_message}
-    assert grader(None, student_input) == expected_result
+    result = grader(None, student_input)
+    assert expected_result == result
+
+def test_debug_message_complex_integrand():
+    grader = IntegralGrader(
+    complex_integrand=True,
+        answers={
+            'lower': '-2',
+            'upper': '4',
+            'integrand': 'cos(s) + i*sin(s)',
+            'integration_variable': 's'
+        },
+        debug=True,
+        samples=2
+    )
+    student_input = ['-1', '5', 'sqrt(x)', 'x']
+    expected_message = (
+        "<pre>MITx Grading Library Version 1.0.3<br/>\n"
+        "Student Responses:<br/>\n"
+        "-1<br/>\n"
+        "5<br/>\n"
+        "sqrt(x)<br/>\n"
+        "x<br/>\n"
+        "<br/>\n"
+        "==============================================<br/>\n"
+        "Integration Data for Sample Number 0<br/>\n"
+        "==============================================<br/>\n"
+        "Variables: {'infty': inf, 'e': 2.718281828459045, 'i': 1j, 'j': 1j, 's': 1.8831785881043805, 'x': 0.022981166359782736, 'pi': 3.141592653589793}<br/>\n"
+        "<br/>\n"
+        "========== Student Integration Data, Real Part<br/>\n"
+        "Numerical Value: 7.453559925<br/>\n"
+        "Error Estimate: 8.27511384416e-15<br/>\n"
+        "Number of integrand evaluations: 357<br/>\n"
+        "========== Student Integration Data, Imaginary Part<br/>\n"
+        "Numerical Value: 0.666666666667<br/>\n"
+        "Error Estimate: 7.40148683083e-16<br/>\n"
+        "Number of integrand evaluations: 357<br/>\n"
+        "<br/>\n"
+        "========== Author Integration Data, Real Part<br/>\n"
+        "Numerical Value: 0.152494931518<br/>\n"
+        "Error Estimate: 4.2752835891e-14<br/>\n"
+        "Number of integrand evaluations: 21<br/>\n"
+        "========== Author Integration Data, Imaginary Part<br/>\n"
+        "Numerical Value: 0.237496784316<br/>\n"
+        "Error Estimate: 4.1882074502e-14<br/>\n"
+        "Number of integrand evaluations: 21<br/>\n"
+        "</pre>"
+    ).replace("VERSION", __version__)
+    expected_result = {'ok': False, 'grade_decimal': 0, 'msg': expected_message}
+    result = grader(None, student_input)
+    assert expected_result == result
 
 def test_error_catching():
     grader = IntegralGrader(
@@ -354,21 +520,36 @@ def test_error_catching():
     with raises(CalcError, msg=expected_message):
         grader(None, student_input)
 
-def test_wrong_answer():
+def test_integral_with_complex_integrand():
     grader = IntegralGrader(
+        complex_integrand=True,
         answers={
             'lower': 'a',
             'upper': 'b',
-            'integrand': 'x^2',
-            'integration_variable': 'x'
+            'integrand': '(cos(q) + i*sin(q))^2',
+            'integration_variable': 'q'
         },
-        input_positions={
-            'integrand': 1,
-            'lower': 2,
-            'upper': 3
-        },
-        variables=['a', 'b']
+        variables=['a', 'b'],
     )
-    student_input = ['x', '2', '3']
-    expect = {'grade_decimal': 0, 'msg': '', 'ok': False}
-    assert grader(None, student_input) == expect
+    # Correct answers
+    correct_input0 = ['a', 'b', 'cos(2*t) + i * sin(2*t)', 't']
+    correct_input1 = ['a', 'b', 'cos(2*t) + i * sin(2*t)', 't']
+    # Incorrect answers
+    wrong_input0 = ['a', 'b', 'i*cos(2*t) + sin(2*t)', 't']
+    wrong_input1 = ['a', 'b', 'cos(2*w)', 'w']
+    wrong_input2 = ['a', 'b', 'i*sin(2*q)', 'q']
+
+    correct_result0 = grader(None, correct_input0)
+    correct_result1 = grader(None, correct_input1)
+    wrong_result0 = grader(None, wrong_input0)
+    wrong_result1 = grader(None, wrong_input1)
+    wrong_result2 = grader(None, wrong_input2)
+
+    correct_expected_result = {'ok': True, 'grade_decimal': 1, 'msg': ''}
+    wrong_expected_result = {'ok': False, 'grade_decimal': 0, 'msg': ''}
+
+    assert correct_result0 == correct_expected_result
+    assert correct_result1 == correct_expected_result
+    assert wrong_result0 == wrong_expected_result
+    assert wrong_result1 == wrong_expected_result
+    assert wrong_result2 == wrong_expected_result

--- a/tests/plugins/test_integralgrader.py
+++ b/tests/plugins/test_integralgrader.py
@@ -259,6 +259,28 @@ def test_integration_options_are_passed_correctly():
     # grader1 avoids the singularity and should work
     assert grader1(None, student_input) == expected_result
 
+def test_complex_integrand_grades_as_expected():
+    grader = IntegralGrader(
+        complex_integrand=True,
+        answers={
+            'lower': 'a',
+            'upper': 'b',
+            'integrand': 'e^(i*x)',
+            'integration_variable': 'x'
+        },
+        variables=['a', 'b'],
+    )
+    # Correct
+    student_input_a = ['a', 'b', 'cos(x)+i*sin(x)', 'x']
+    expected_a = {'ok': True, 'grade_decimal': 1, 'msg': ''}
+    assert grader(None, student_input_a) == expected_a
+    # correct real part / imag part
+    student_input_b1 = ['a', 'b', 'cos(x)+i*x', 'x']
+    student_input_b2 = ['a', 'b', 'x+i*sin(x)', 'x']
+    expected_b = {'ok': False, 'grade_decimal': 0, 'msg': ''}
+    assert grader(None, student_input_b1) == expected_b
+    assert grader(None, student_input_b2) == expected_b
+
 # Integral Evaluation Error tests
 def test_learner_divergent_integral_real_part_raises_integration_error():
     msg = ("There appears to be an error with the integral you entered: "
@@ -363,7 +385,7 @@ def test_student_has_complex_limits_raises_IntegrationError():
         student_input = ['0', 'sqrt(1-a^2)', 'x^2', 'x']
         grader(None, student_input)
 
-def test_athor_has_complex_integrand_raises_ConfigError():
+def test_athor_has_unexpected_complex_integrand_raises_ConfigError():
     with raises(ConfigError, match="Integration Error with author's stored answer: Integrand"):
         grader = IntegralGrader(
             answers={
@@ -380,7 +402,7 @@ def test_athor_has_complex_integrand_raises_ConfigError():
         student_input = ['0', '1', 'x^2', 'x']
         grader(None, student_input)
 
-def test_student_has_complex_integrand_raises_IntegrationError():
+def test_student_has_unexpected_complex_integrand_raises_IntegrationError():
     with raises(IntegrationError,
                 match=(
                     "There appears to be an error "

--- a/tests/plugins/test_integralgrader.py
+++ b/tests/plugins/test_integralgrader.py
@@ -260,7 +260,7 @@ def test_integration_options_are_passed_correctly():
     assert grader1(None, student_input) == expected_result
 
 # Integral Evaluation Error tests
-def test_divergent_integral_infinite_domain_raises_error():
+def test_learner_divergent_integral_real_part_raises_integration_error():
     msg = ("There appears to be an error with the integral you entered: "
            "The integral is probably divergent, or slowly convergent.")
     with raises(IntegrationError, match=msg):
@@ -275,13 +275,43 @@ def test_divergent_integral_infinite_domain_raises_error():
         student_input = ['0', '1', '1/x^2', 'x']
         grader(None, student_input)
 
-def test_divergent_integral_config_raises_error():
+def test_author_divergent_integral_real_part_raises_config_error():
     with raises(ConfigError, match="The algorithm does not converge"):
         grader = IntegralGrader(
             answers={
                 'lower': '-1',
                 'upper': '1',
                 'integrand': '1/(x-0.276)^2',
+                'integration_variable': 'x'
+            }
+        )
+        student_input = ['-1', '1', 'x^2', 'x']
+        grader(None, student_input)
+
+def test_learner_divergent_integral_imag_part_raises_integration_error():
+    msg = ("There appears to be an error with the integral you entered: "
+           "The integral is probably divergent, or slowly convergent.")
+    with raises(IntegrationError, match=msg):
+        grader = IntegralGrader(
+            complex_integrand=True,
+            answers={
+                'lower': '1',
+                'upper': 'infty',
+                'integrand': 'e^(-x) + i/x^2',
+                'integration_variable': 'x'
+            }
+        )
+        student_input = ['0', '1', 'e^(-x) + i/x^2', 'x']
+        grader(None, student_input)
+
+def test_author_divergent_integral_imag_part_raises_config_error():
+    with raises(ConfigError, match="The algorithm does not converge"):
+        grader = IntegralGrader(
+            complex_integrand=True,
+            answers={
+                'lower': '-1',
+                'upper': '1',
+                'integrand': 'x + i/(x-0.276)^2',
                 'integration_variable': 'x'
             }
         )


### PR DESCRIPTION
This PR improves IntegralGrader's handling of complex numbers. The integrator we use (scipy.integrate.quad) cannot handle complex limits. So:

- Raise a ConfigError if author-specified upper/lower limits evaluate to complex
- Raise an IntegrationError if learner-specified upper/lower limits evaluate to complex

The `scipy.integrate.quad` integrator also cannot handle complex integrands by itself. But we can pass real and imaginary parts to the integrator separately. So this PR adds a configuration option `complex_integrand` (default is False) such that:

- if `complex_integrand:False` and integrand evaluates to complex, raise IntegrationError
- if `complex_integrand:True`, evaluate real/imaginary parts separately and compare author/learner values.

Debug messages and tests also updated.