### PR TITLE
refactor forbidden string check and move after correctness check

### DIFF
--- a/tests/test_formulagrader.py
+++ b/tests/test_formulagrader.py
@@ -314,19 +314,23 @@ def test_fg_case_sensitive():
 def test_fg_forbidden():
     """Test FormulaGrader with forbidden strings in input"""
     grader = FormulaGrader(
-        answers="sin(3*pi/2)",
-        forbidden_strings=['3*pi', 'pi*3', 'pi/2'],
+        answers="2*sin(x)*cos(x)",
+        variables=['x'],
+        forbidden_strings=['+ x', '- x', '*x'],
         case_sensitive=False
     )
-    assert grader(None, '-1')['ok']
+    assert grader(None, '2*sin(x)*cos(x)')['ok']
+
+    # If the answer is mathematically correct AND contains forbidden strings, raise an error:
     with raises(InvalidInput, match="Invalid Input: This particular answer is forbidden"):
-        grader(None, "3 * pi")
+        grader(None, "sin(2 * x)")
     with raises(InvalidInput, match="Invalid Input: This particular answer is forbidden"):
-        grader(None, "pi * 3")
+        grader(None, "sin(x    +    x)")
     with raises(InvalidInput, match="Invalid Input: This particular answer is forbidden"):
-        grader(None, "sin(3*PI   /2)")
-    with raises(InvalidInput, match="Invalid Input: This particular answer is forbidden"):
-        grader(None, "sin(PI*3/      2)")
+        grader(None, "sin(3*X    -X)")
+
+    # If the answer is mathematically incorrect AND contains a forbidden string, mark it wrong
+    assert not grader(None, "sin(3*x)")['ok']
 
 def test_fg_variables():
     """General test of FormulaGrader using variables"""


### PR DESCRIPTION
This resolves #33 and moves the forbidden string check after the correctness check, as requested by Stepan at Harvard:

> ... extremely useful, especially the "forbidden string" feature for problems where we ask users to simplify an expression like "a^2 * a^b" to a single exponential by forbidding "*".
>
> However, we have run into an issue that we want to get your thoughts on. The package currently checks first for forbidden strings, and then for correct evaluation. For the problem above, a response of "a^(2*b)" would fail both checks, but since the forbidden string test happens first, the user gets a yellow-light message like "Please simplify completely." We could change the yellow-light message to something more generic, but we think a more natural solution would be to perform the evaluation check first (breaking to a red-light "Incorrect" message if it fails), and the forbidden string check second. We wanted to hear your thoughts on this scheme before trying to implement it, and see if you had run into similar issues. 