### PR TITLE
Adding no cover option to line that cannot be triggered

### DIFF
--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -142,7 +142,7 @@ class AbstractGrader(ObjectWithSchema):
             if "input_list" in result:
                 # Multiple inputs
                 if result.get('overall_message', ''):
-                    result['overall_message'] += "\n\n" + self.log_output()
+                    result['overall_message'] += "\n\n" + self.log_output()  # pragma: no cover
                 else:
                     result['overall_message'] = self.log_output()
             else:


### PR DESCRIPTION
This just tells coverage that there is a line that cannot be tested. While the framework supports adding an overall message to a multi-input problem, nothing can currently generate such a message.