### PR TITLE
validate user-defined variables don't conflict, warn if override

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,16 @@ You cannot 'mix and match' these two options. If a configuration dictionary is s
 
 ## Options
 
-Every grading class has a debug option. By default, `debug=False`. To receive debug information from a given grader, specify `debug=True`. Some graders will provide more debug information than others.
+The options passed to a grading class undergo extensive validation and graders will throw
+errors if instantiated with invalid options.
+
+A few error messages serve only as warnings (e.g., that you are attempting to override a default constant like `pi`). These warning errors can be suppressed by setting
+
+````python
+grader = GradingClass(suppress_warnings=True)
+````
+
+Every grading class also has a debug option. By default, `debug=False`. To receive debug information from a given grader, specify `debug=True`. Some graders will provide more debug information than others.
 
 ````python
 grader = GradingClass(debug=True)

--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -83,7 +83,8 @@ class AbstractGrader(ObjectWithSchema):
         Classes that inherit from AbstractGrader should extend this schema.
         """
         return Schema({
-            Required('debug', default=False): bool  # Use to turn on debug output
+            Required('debug', default=False): bool,  # Use to turn on debug output
+            Required('suppress_warnings', default=False): bool
         })
 
     @abc.abstractmethod

--- a/mitxgraders/helpers/validatorfuncs.py
+++ b/mitxgraders/helpers/validatorfuncs.py
@@ -3,6 +3,7 @@ validatorfuncs.py
 
 Stand-alone validator functions for use in voluptuous Schema
 """
+import itertools
 from numbers import Number
 from inspect import getargspec
 from mitxgraders.voluptuous import All, Range, NotIn, Invalid, Schema, Any, Required, Length, truth
@@ -79,6 +80,38 @@ def ListOfType(given_type, validator=None):
         return schema(config_input)
     return func
 
+def all_unique(iterable):
+    """
+    Voluptuous validator; tests whether all items in an iterable are unique
+
+    Usage
+    =====
+
+    Returns the input if all items are unique:
+    >>> iterable = ['a', 0, '1', '5']
+    >>> all_unique(iterable) == iterable
+    True
+
+    Raises an error if any items are duplicated:
+    >>> iterable = ['a', 0, '1', 'a', '5', 0, '0']
+    >>> all_unique(iterable)
+    Traceback (most recent call last):
+    Invalid: items should be unique, but have unexpected duplicates: ['a', 0]
+    """
+    seen = set()
+    duplicates = set()
+    for item in iterable:
+        if item in seen:
+            duplicates.add(item)
+        else:
+            seen.add(item)
+
+    if duplicates:
+        msg = 'items should be unique, but have unexpected duplicates: {duplicates}'
+        raise Invalid(msg.format(iterable=iterable, duplicates=list(duplicates)))
+
+    return iterable
+
 @truth
 def is_callable(obj):
     """Returns true if obj is callable"""
@@ -136,7 +169,6 @@ def get_number_of_args(callable_obj):
         pass
 
     return num_args
-
 
 def is_callable_with_args(num_args):
     """

--- a/tests/test_formulagrader.py
+++ b/tests/test_formulagrader.py
@@ -39,19 +39,9 @@ def test_half_power_of_negative_number():
 
 def test_overriding_functions():
     grader = FormulaGrader(
-        answers='z^2',
-        variables=['z'],
-        user_functions={'re': RandomFunction(), 'im': RandomFunction()},
-        sample_from={
-            'z': ComplexRectangle()
-        }
-    )
-    learner_input = 're(z)^2 - im(z)^2 + 2*i*re(z)*im(z)'
-    assert not grader(None, learner_input)['ok']
-
-    grader = FormulaGrader(
         answers='tan(1)',
-        user_functions={'sin': lambda x: x}
+        user_functions={'sin': lambda x: x},
+        suppress_warnings=True
     )
     assert grader(None, 'tan(1)')['ok']
     assert not grader(None, 'sin(1)/cos(1)')['ok']
@@ -734,7 +724,8 @@ def test_docs():
     grader = FormulaGrader(
         answers="x^2",
         variables=['x'],
-        user_functions={"sin": lambda x: x*x}
+        user_functions={"sin": lambda x: x*x},
+        suppress_warnings=True
     )
     assert grader(None, 'sin(x)')['ok']
 


### PR DESCRIPTION
This addresses #51:

- In FormulaGrader: if variables, numbered_vars, user_constants overlap, raise an error.
- In IntegralGrader: if variables and user_constants overlap, raise an error.

For both FormulaGrader and IntegralGrader, if any user-defined variable/function overrides a default, raise an error that can be suppressed with `suppress_warnings=True`.