### PR TITLE
Tidying up calc.py

### DIFF
--- a/mitxgraders/helpers/mathfunc.py
+++ b/mitxgraders/helpers/mathfunc.py
@@ -16,7 +16,6 @@ from __future__ import division
 import math
 import numpy as np
 import scipy.special as special
-from mitxgraders.baseclasses import ConfigError
 
 # Normal Trig
 def sec(arg):

--- a/tests/helpers/test_calc.py
+++ b/tests/helpers/test_calc.py
@@ -4,6 +4,7 @@ Tests of calc.py
 from __future__ import division
 import math
 import random
+import re
 import numpy as np
 from pytest import raises, approx
 from mitxgraders import CalcError
@@ -126,3 +127,20 @@ def test_vectors():
     msg = "Vector and matrix expressions have been forbidden in this entry"
     with raises(UnableToParse, match=msg):
         evaluator("[[1, 2], [3, 4]]", {}, {}, {})
+
+def test_negation():
+    """Test that appropriate numbers of +/- signs are accepted"""
+    assert evaluator("1+-1")[0] == 0
+    assert evaluator("1--1")[0] == 2
+    assert evaluator("2*-1")[0] == -2
+    assert evaluator("2/-4")[0] == -0.5
+    assert evaluator("-1+-1")[0] == -2
+    assert evaluator("+1+-1")[0] == 0
+    assert evaluator("2^-2")[0] == 0.25
+    assert evaluator("+-1")[0] == -1
+
+    msg = "Invalid Input: Could not parse '{}' as a formula"
+    badformulas = ["1---1", "2^--2", "1-+2", "1++2", "1+++2", "--2", "---2", "-+2", "--+2"]
+    for formula in badformulas:
+        with raises(UnableToParse, match=re.escape(msg.format(formula))):
+            evaluator(formula)


### PR DESCRIPTION
This does a bunch of tidying in calc.py.

* `evaluator` now has default arguments for variables, functions and suffixes.
* Made all negative signs limited to just one, and made a bunch of tests to ensure compliance.
* Moved one-line pyparsing actions to lambda functions.
* Cleaned up `dump_parse_result`
* Gave names to all symbols in the parser tree, so that you don't see any more `ITEM` tags in the debug dump. Eg., `1+2^-2*sin(x)` now parses to the following debug tree:

```XML
<sum>
  <number>
    <num>1</num>
  </number>
  <op>+</op>
  <product>
    <power>
      <number>
        <num>2</num>
      </number>
      <op>-</op>
      <number>
        <num>2</num>
      </number>
    </power>
    <op>*</op>
    <function>
      <funcname>sin</funcname>
      <arguments>
        <variable>
          <varname>x</varname>
        </variable>
      </arguments>
    </function>
  </product>
</sum>
```

I was trying to get the variable tags to work as `<variable>x</variable>`, but I couldn't seem to get that to happen...