### PR TITLE
Implementing correlated grading

### DIFF
--- a/mitxgraders/plugins/integralgrader.py
+++ b/mitxgraders/plugins/integralgrader.py
@@ -336,7 +336,7 @@ class IntegralGrader(AbstractGrader):
 
         return structured_input
 
-    def check(self, answers, student_input):
+    def check(self, answers, student_input, **kwargs):
         """Validates and cleans student_input, then checks response and handles errors"""
         answers = self.config['answers'] if answers is None else answers
         structured_input = self.structure_and_validate_input(student_input)
@@ -518,7 +518,7 @@ class IntegralGrader(AbstractGrader):
             errmsg = "Integrand has evaluated to complex number but must evaluate to a real."
             integrand = check_output_is_real(raw_integrand, IntegrationError, errmsg)
             result_re = integrate.quad(integrand, lower, upper, **self.config['integrator_options'])
-            result_im = (None, None, {'neval':None})
+            result_im = (None, None, {'neval': None})
 
         # Restore the integration variable's initial value now that we are done integrating
         if int_var_initial is not None:

--- a/mitxgraders/stringgrader.py
+++ b/mitxgraders/stringgrader.py
@@ -33,7 +33,7 @@ class StringGrader(ItemGrader):
             Required('case_sensitive', default=True): bool
         })
 
-    def check_response(self, answer, student_input):
+    def check_response(self, answer, student_input, **kwargs):
         """
         Grades a student response against a given answer
 


### PR DESCRIPTION
This PR adds a `dependent_input` config variable to each `ItemGrader` class that specifies which inputs are required to perform the check for that `ItemGrader`. When a lowest-level `ListGrader` has ordered input with individual subgraders, it reads the `dependent_input` list from each subgrader. Those with empty lists, it evaluates. Those that have dependencies, it passes through to the `check` function as a keyword argument.

I've implemented `dependent_input` for `FormulaGrader` only (and `NumericalGrader` by subclassing). For `FormulaGrader`, the dependencies are computed after variables have been sampled. The dependencies are labelled `input_n`, and added to the variables list before computing any `comparer_params`. This means that `input_n` dependencies can be used in the answer strings for such graders without needing a custom comparer. The `input_n` variables are scrubbed from the variables list before the student input is checked, so students cannot take advantage of it.

This was actually surprisingly straightforward to implement. So far however, this is just the raw implementation. This still needs the following:

- [x] Implementation
- [ ] Validation
- [ ] Documentation
- [ ] Course example
- [ ] Tests

Addresses issue #46.