### PR TITLE
Pass siblings

### DIFF
--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -102,8 +102,8 @@ class AbstractGrader(ObjectWithSchema):
         Arguments:
             answers: The expected result(s) and grading information
             student_input: The student's input passed by edX
-            **kwargs: Anything else that has been passed in For example, sibling
-                graders when a grader is used as a subgrader ing a ListGrader.
+            **kwargs: Anything else that has been passed in. For example, sibling
+                graders when a grader is used as a subgrader in a ListGrader.
         """
 
     def __call__(self, expect, student_input):
@@ -311,8 +311,8 @@ class ItemGrader(AbstractGrader):
         Arguments:
             answer: A tuple of answers to compare to, or None to use internal config
             student_input (str): The student's input passed by edX
-            **kwargs: Anything else that has been passed in For example, sibling
-                graders when a grader is used as a subgrader ing a ListGrader.
+            **kwargs: Anything else that has been passed in. For example, sibling
+                graders when a grader is used as a subgrader in a ListGrader.
         """
         # If no answers provided, use the internal configuration
         answers = self.config['answers'] if answers is None else answers
@@ -354,6 +354,6 @@ class ItemGrader(AbstractGrader):
         Arguments:
             answer (schema_answer): The answer to compare to
             student_input (str): The student's input passed by edX
-            **kwargs: Anything else that has been passed in For example, sibling
-                graders when a grader is used as a subgrader ing a ListGrader.
+            **kwargs: Anything else that has been passed in. For example, sibling
+                graders when a grader is used as a subgrader in a ListGrader.
         """

--- a/mitxgraders/formulagrader.py
+++ b/mitxgraders/formulagrader.py
@@ -589,6 +589,11 @@ class FormulaGrader(ItemGrader):
         return variable_list, sample_from_dict
 
     @staticmethod
+    def sibling_varname(index):
+        """Generate name for sibling variables"""
+        return 'sibling_{}'.format(index + 1)
+
+    @staticmethod
     def get_sibling_formulas(siblings):
         """
         Returns a dict sibling formula inputs.
@@ -600,7 +605,7 @@ class FormulaGrader(ItemGrader):
         formula_siblings = [(i, sibling['input']) for i, sibling in enumerate(siblings)
                             if isinstance(sibling['grader'], FormulaGrader)]
         return {
-            "sibling_{}".format(i+1): sibling_input
+            FormulaGrader.sibling_varname(i): sibling_input
             for i, sibling_input in formula_siblings
         }
 

--- a/mitxgraders/formulagrader.py
+++ b/mitxgraders/formulagrader.py
@@ -656,7 +656,7 @@ class FormulaGrader(ItemGrader):
             comparer_params_eval = self.eval_and_validate_comparer_params(
                 scoped_eval, answer['expect']['comparer_params'], siblings_eval)
 
-            # Before performing student evaluation, scrub the dependencies
+            # Before performing student evaluation, scrub the siblings
             # so that students can't use them
             for key in siblings_eval:
                 del varlist[key]
@@ -666,7 +666,7 @@ class FormulaGrader(ItemGrader):
             # Check if expressions agree
             comparer_result = comparer(comparer_params_eval, student_eval, self.comparer_utils)
             if self.config['debug']:
-                # Put the dependencies back in for the debug output
+                # Put the siblings back in for the debug output
                 varlist.update(siblings_eval)
                 self.log_sample_info(i, varlist, funclist, student_eval,
                                      comparer, comparer_params_eval, comparer_result)
@@ -691,7 +691,7 @@ class FormulaGrader(ItemGrader):
 
         Arguments
         =========
-        - scoped_eval (func): a unuary function to evaluate math expressions.
+        - scoped_eval (func): a unary function to evaluate math expressions.
         Basically, calc.py's evaluator but with variables/functions/suffixes
         already passed in.
         - comparer_params ([str]): unevaluated expressions

--- a/mitxgraders/formulagrader.py
+++ b/mitxgraders/formulagrader.py
@@ -600,7 +600,7 @@ class FormulaGrader(ItemGrader):
         formula_siblings = [(i, sibling['input']) for i, sibling in enumerate(siblings)
                             if isinstance(sibling['grader'], FormulaGrader)]
         return {
-            "input_{}".format(i+1): sibling_input
+            "sibling_{}".format(i+1): sibling_input
             for i, sibling_input in formula_siblings
         }
 

--- a/mitxgraders/helpers/calc.py
+++ b/mitxgraders/helpers/calc.py
@@ -10,6 +10,7 @@ Heavily modified from the edX calc.py
 from __future__ import division
 import copy
 import numpy as np
+from collections import namedtuple
 from pyparsing import (
     CaselessLiteral,
     Combine,
@@ -169,6 +170,8 @@ class ParserCache(object):
 
 # The global parser cache
 parsercache = ParserCache()
+
+ScopeUsage = namedtuple('ScopeUSage', ['functions', 'variables', 'suffixes'])
 
 def evaluator(formula,
               variables=DEFAULT_VARIABLES,

--- a/mitxgraders/helpers/calc.py
+++ b/mitxgraders/helpers/calc.py
@@ -171,7 +171,7 @@ class ParserCache(object):
 # The global parser cache
 parsercache = ParserCache()
 
-ScopeUsage = namedtuple('ScopeUSage', ['functions', 'variables', 'suffixes'])
+ScopeUsage = namedtuple('ScopeUSage', ['variables', 'functions', 'suffixes'])
 
 def evaluator(formula,
               variables=DEFAULT_VARIABLES,
@@ -181,29 +181,53 @@ def evaluator(formula,
     """
     Evaluate an expression; that is, take a string of math and return a float.
 
-    -Variables are passed as a dictionary from string to value. They must be
-     python numbers.
-    -Unary functions are passed as a dictionary from string to function.
-    -Everything is case sensitive (note, this is different to edX!)
+    Arguments
+    =========
+    - formula (str): The formula to be evaluated
+    Pass a scope consisting of variables, functions, and suffixes:
+    - variables (dict): maps strings to variable values
+    - functions (dict): maps strings to functions
+    - suffixes (dict): maps strings to suffix values
+    Also:
+    - max_array_dim: Maximum dimension of MathArrays
+
+    NOTE: Everything is case sensitive (this is different to edX!)
 
     Usage
     =====
-    >>> evaluator("1+1", {}, {}, {})
-    (2.0, set([]))
-    >>> evaluator("1+x", {"x": 5}, {}, {})
-    (6.0, set([]))
-    >>> evaluator("square(2)", {}, {"square": lambda x: x*x}, {})
-    (4.0, set(['square']))
-    >>> evaluator("", {}, {}, {})
-    (nan, set([]))
+    Evaluates the formula and records usage of functions/variables/suffixes:
+    >>> result = evaluator("1+1", {}, {}, {})
+    >>> expected = ( 2.0 , ScopeUsage(
+    ...     variables=set(),
+    ...     functions=set(),
+    ...     suffixes=set()
+    ... ))
+    >>> result == expected
+    True
+    >>> result = evaluator("square(x) + 5k",
+    ...     variables={'x':5, 'y': 10},
+    ...     functions={'square': lambda x: x**2, 'cube': lambda x: x**3},
+    ...     suffixes={'%': 0.01, 'k': 1000  })
+    >>> expected = ( 5025.0 , ScopeUsage(
+    ...     variables=set(['x']),
+    ...     functions=set(['square']),
+    ...     suffixes=set(['k'])
+    ... ))
+    >>> result == expected
+    True
+
+    Empty submissions evaluate to nan:
+    >>> evaluator("", {}, {}, {})[0]
+    nan
     """
+    empty_usage = ScopeUsage(set(), set(), set())
     if formula is None:
         # No need to go further.
-        return float('nan'), set()
+        return float('nan'), empty_usage
     formula = formula.strip()
     if formula == "":
         # No need to go further.
-        return float('nan'), set()
+        return float('nan'), empty_usage
 
     # Parse the tree
     math_interpreter = parsercache.get_parser(formula, suffixes)
@@ -238,7 +262,10 @@ def evaluator(formula,
         raise UnableToParse(msg)
 
     # Return the result of the evaluation, as well as the set of functions used
-    return result, math_interpreter.functions_used
+    usage = ScopeUsage(variables=math_interpreter.variables_used,
+                      functions=math_interpreter.functions_used,
+                      suffixes=math_interpreter.suffixes_used)
+    return result, usage
 
 class FormulaParser(object):
     """
@@ -255,6 +282,7 @@ class FormulaParser(object):
         self.tree = None
         self.variables_used = set()
         self.functions_used = set()
+        self.suffixes_used = set()
         self.max_array_dim_used = 0
         self.suffixes = suffixes
         self.actions = {
@@ -284,6 +312,12 @@ class FormulaParser(object):
         When a function is recognized, store it in `functions_used`.
         """
         self.functions_used.add(tokens[0][0])
+
+    def suffix_parse_action(self, tokens):
+        """
+        When a suffix is recognized, store it in `suffixes_used`.
+        """
+        self.suffixes_used.add(tokens[0][0])
 
     @staticmethod
     def group_if_multiple(name):
@@ -325,6 +359,7 @@ class FormulaParser(object):
 
         # Define our suffixes
         suffix = MatchFirst(Literal(k) for k in self.suffixes.keys())
+        suffix.setParseAction(self.suffix_parse_action)
 
         # Construct a number as a group consisting of a text string (num) and an optional
         # suffix num can include a decimal number and numerical exponent, and can be

--- a/mitxgraders/helpers/specify_domain.py
+++ b/mitxgraders/helpers/specify_domain.py
@@ -5,7 +5,7 @@ Defines class SpecifyDomain, an author-facing decorator for specifying the domai
 of a function. Currently only supports specifying the shape of inputs.
 """
 from numbers import Number
-from voluptuous import Schema, Invalid, All, Any, Required, Coerce
+from voluptuous import Schema, Invalid, Required
 from mitxgraders.helpers.validatorfuncs import is_shape_specification
 from mitxgraders.baseclasses import StudentFacingError, ObjectWithSchema
 from mitxgraders.helpers.math_array import MathArray, is_scalar_matharray

--- a/mitxgraders/listgrader.py
+++ b/mitxgraders/listgrader.py
@@ -452,7 +452,7 @@ class ListGrader(AbstractGrader):
         Pass answers and inputs to the appropriate grader, along with sibling
         information.
         """
-        # If 'subgradres' is a single grader, create a list of references to it.
+        # If 'subgraders' is a single grader, create a list of references to it.
         graders = (self.config['subgraders'] if self.subgrader_list
                    else [self.config['subgraders'] for _ in answers])
         compare = zip(graders, answers, grouped_inputs)

--- a/mitxgraders/plugins/integralgrader.py
+++ b/mitxgraders/plugins/integralgrader.py
@@ -464,22 +464,22 @@ class IntegralGrader(AbstractGrader):
                              varscope, funcscope):
         """Evals lower/upper limits and gets the functions used in lower/upper/integrand"""
 
-        lower, lower_funcs = evaluator(lower_str,
+        lower, lower_used = evaluator(lower_str,
                                        variables=varscope,
                                        functions=funcscope,
                                        suffixes={})
-        upper, upper_funcs = evaluator(upper_str,
+        upper, upper_used = evaluator(upper_str,
                                        variables=varscope,
                                        functions=funcscope,
                                        suffixes={})
 
         varscope[integration_var] = (upper + lower)/2
-        _, integrand_funcs = evaluator(integrand_str,
+        _, integrand_used = evaluator(integrand_str,
                                        variables=varscope,
                                        functions=funcscope,
                                        suffixes={})
 
-        used_funcs = lower_funcs.union(upper_funcs).union(integrand_funcs)
+        used_funcs = lower_used.functions.union(upper_used.functions).union(integrand_used.functions)
 
         return lower, upper, used_funcs
 

--- a/mitxgraders/plugins/integralgrader.py
+++ b/mitxgraders/plugins/integralgrader.py
@@ -336,7 +336,7 @@ class IntegralGrader(AbstractGrader):
 
         return structured_input
 
-    def check(self, answers, student_input):
+    def check(self, answers, student_input, **kwargs):
         """Validates and cleans student_input, then checks response and handles errors"""
         answers = self.config['answers'] if answers is None else answers
         structured_input = self.structure_and_validate_input(student_input)
@@ -518,7 +518,7 @@ class IntegralGrader(AbstractGrader):
             errmsg = "Integrand has evaluated to complex number but must evaluate to a real."
             integrand = check_output_is_real(raw_integrand, IntegrationError, errmsg)
             result_re = integrate.quad(integrand, lower, upper, **self.config['integrator_options'])
-            result_im = (None, None, {'neval':None})
+            result_im = (None, None, {'neval': None})
 
         # Restore the integration variable's initial value now that we are done integrating
         if int_var_initial is not None:

--- a/mitxgraders/stringgrader.py
+++ b/mitxgraders/stringgrader.py
@@ -33,7 +33,7 @@ class StringGrader(ItemGrader):
             Required('case_sensitive', default=True): bool
         })
 
-    def check_response(self, answer, student_input):
+    def check_response(self, answer, student_input, **kwargs):
         """
         Grades a student response against a given answer
 

--- a/tests/helpers/calc/test_calc.py
+++ b/tests/helpers/calc/test_calc.py
@@ -20,18 +20,19 @@ def test_calcpy():
         evaluator("1+f(2)", {}, {"f": badfunc}, {})
 
     # Test formula with None
-    result = evaluator(None, {}, {}, {})
-    assert result[0] == approx(float('nan'), nan_ok=True)
-    assert result[1] == set()
+    value, used = evaluator(None, {}, {}, {})
+    assert value == approx(float('nan'), nan_ok=True)
+    assert (used.functions, used.variables, used.suffixes) == (set(), set(), set())
+
 
     # Test formulae with parallel operator
-    result = evaluator("1 || 1 || 1", {}, {}, {})
-    assert result[0] == 1/3
-    assert result[1] == set()
+    value, used = evaluator("1 || 1 || 1", {}, {}, {})
+    assert value == 1/3
+    assert (used.functions, used.variables, used.suffixes) == (set(), set(), set())
 
-    result = evaluator("1 || 1 || 0", {}, {}, {})
-    assert result[0] == approx(float('nan'), nan_ok=True)
-    assert result[1] == set()
+    value, used = evaluator("1 || 1 || 0", {}, {}, {})
+    assert value == approx(float('nan'), nan_ok=True)
+    assert (used.functions, used.variables, used.suffixes) == (set(), set(), set())
 
     # Test incorrect case variables
     msg = r"Invalid Input: X not permitted in answer as a variable \(did you mean x\?\)"


### PR DESCRIPTION
This PR addresses #46 by passing a `siblings` keyword argument to the `check` function of subgraders in a `ListGrader`. This parameter is only available when `ordered=true`.

Currently only FormulaGrader makes any use of `siblings` in its check function. Example:
```python
grader=ListGrader(
    answers=['sibling_3 + 1', 'sibling_1^2', 'x'],
    subgraders=FormulaGrader(variables=['x']),
    ordered=True
)
grader(None, ['x + 1', 'x^2 + 2*x + 1', 'x'])
```
Some notes:

- This is a refactoring of #65, see discussion there.
- No author-facing documentation or course examples, though I've added that to the list of required documentation in #78 
- I've changed the sibling variable names from `input_k` to `sibling_k` to stress that the relationship is relative; particularly relevant when used with grouping / nested ListGraders.