### PR TITLE
Grading incompatible types

### DIFF
--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -464,12 +464,11 @@ class FormulaGrader(ItemGrader):
         Required('comparer'): is_callable_with_args(3)
     })
 
-    @classmethod
-    def validate_expect(cls, expect):
+    def validate_expect(self, expect):
         """
         Validate the answers's expect key.
 
-        >>> result = FormulaGrader.validate_expect('mc^2')
+        >>> result = FormulaGrader().validate_expect('mc^2')
         >>> expected = {
         ... 'comparer_params': ['mc^2'],
         ... 'comparer': FormulaGrader.default_equality_comparer
@@ -478,13 +477,13 @@ class FormulaGrader(ItemGrader):
         True
         """
         if isinstance(expect, str):
-            return cls.schema_expect({
-                'comparer': cls.default_equality_comparer,
+            return self.schema_expect({
+                'comparer': self.default_equality_comparer,
                 'comparer_params': [expect]
                 })
 
         try:
-            return cls.schema_expect(expect)
+            return self.schema_expect(expect)
         except Invalid:
             # Only raise the detailed error message if author is trying to use comparer.
             if isinstance(expect, dict) and 'comparer' in expect:

--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -399,9 +399,9 @@ class FormulaGrader(ItemGrader):
             If a dictionary is supplied, it needs keys:
                 - comparer_params: a list of strings to be numerically sampled and passed to the
                     comparer function.
-                - comparer: a function with signature `comparer(comparer_params_evals, student_eval,
-                    utils)` that compares student and comparer_params after evaluation. This function
-                    should return `True`, `False`, `partial`, or a with required key 'grade_decimal'
+                - comparer: a function with signature comparer(comparer_params_evals, student_eval,
+                    utils) that compares student and comparer_params after evaluation. This function
+                    should return True, False, 'partial', or a with required key 'grade_decimal'
                     and optional key 'msg'.
     """
 

--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -3,6 +3,7 @@ formulagrader.py
 """
 from __future__ import division
 from numbers import Number
+from functools import wraps
 from collections import namedtuple
 from pprint import PrettyPrinter
 import re
@@ -513,7 +514,7 @@ class FormulaGrader(ItemGrader):
         "Student Eval: {student_eval}\n"
         "Compare to:  {compare_parms_eval}\n"  # compare_parms_eval is list, so start 1 char earlier
         "Comparer Function: {comparer}\n"
-        "Comparison Satisfied: {comparer_result}\n"
+        "Comparison Result: {comparer_result}\n"
         ""
     )
 
@@ -690,16 +691,17 @@ class FormulaGrader(ItemGrader):
 
             # Check if expressions agree
             comparer_result = comparer(comparer_params_eval, student_eval, self.comparer_utils)
+            comparer_result = ItemGrader.standardize_cfn_return(comparer_result)
             if self.config['debug']:
                 # Put the siblings back in for the debug output
                 varlist.update(siblings_eval)
                 self.log_sample_info(i, varlist, funclist, student_eval,
                                      comparer, comparer_params_eval, comparer_result)
 
-            if not comparer_result:
+            if not comparer_result['ok']:
                 num_failures += 1
                 if num_failures > self.config["failable_evals"]:
-                    return {'ok': False, 'grade_decimal': 0, 'msg': ''}, used.functions
+                    return comparer_result, used.functions
 
         # This response appears to agree with the expected answer
         return {
@@ -754,7 +756,7 @@ class FormulaGrader(ItemGrader):
             variables=pp.pformat(varlist),
             student_eval=student_eval,
             comparer=re.sub(r"0x[0-9a-fA-F]+", "0x...", str(comparer)),
-            comparer_result=comparer_result,
+            comparer_result=pp.pformat(comparer_result),
             compare_parms_eval=pp.pformat(comparer_params_eval)
         ))
 

--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -400,7 +400,9 @@ class FormulaGrader(ItemGrader):
                 - comparer_params: a list of strings to be numerically sampled and passed to the
                     comparer function.
                 - comparer: a function with signature `comparer(comparer_params_evals, student_eval,
-                    utils)` that compares student and comparer_params after evaluation.
+                    utils)` that compares student and comparer_params after evaluation. This function
+                    should return `True`, `False`, `partial`, or a with required key 'grade_decimal'
+                    and optional key 'msg'.
     """
 
     default_functions = DEFAULT_FUNCTIONS.copy()

--- a/mitxgraders/formulagrader/matrixgrader.py
+++ b/mitxgraders/formulagrader/matrixgrader.py
@@ -100,10 +100,12 @@ class MatrixGrader(FormulaGrader):
                 expected_shape = get_description(comparer_params[0], detailed=detailed)
                 received_shape = get_description(student_input, detailed=detailed)
                 if not detailed and expected_shape == received_shape:
-                    msg = ("Exepected answer to be a {0}, but input is a {1}."
-                           "of incorrect shape.".format(expected_shape, received_shape))
-                msg = ("Exepected answer to be a {0}, but input is a {1}."
-                       .format(expected_shape, received_shape))
+                    msg = ("Expected answer to be a {0}, but input is a {1} "
+                           "of incorrect shape".format(expected_shape, received_shape))
+                else:
+                    msg = ("Expected answer to be a {0}, but input is a {1}"
+                        .format(expected_shape, received_shape))
+
             if is_raised:
                 raise ShapeError(msg)
             else:

--- a/mitxgraders/formulagrader/matrixgrader.py
+++ b/mitxgraders/formulagrader/matrixgrader.py
@@ -159,7 +159,7 @@ class MatrixGrader(FormulaGrader):
 
         Assumes comparer_params is just the single expected answer wrapped in a list.
         """
-        expected_input =comparer_params[0]
+        expected_input = comparer_params[0]
         # in numpy, scalars have empty tuples as their shapes
         shape = tuple() if isinstance(expected_input, Number) else expected_input.shape
         utils.validate_shape(student_input, shape)

--- a/mitxgraders/formulagrader/matrixgrader.py
+++ b/mitxgraders/formulagrader/matrixgrader.py
@@ -4,13 +4,14 @@ matrixgrader.py
 Defines a FormulaGrader subtype that handles matrices, too.
 """
 from mitxgraders.formulagrader.formulagrader import FormulaGrader
-from voluptuous import Required
+from voluptuous import Required, Any
 from mitxgraders.helpers.validatorfuncs import NonNegative
 from mitxgraders.helpers.calc import IdentityMultiple, MathArray
 from mitxgraders.helpers.calc.exceptions import (
     MathArrayShapeError as ShapeError)
 from mitxgraders.helpers.calc.mathfuncs import (
     merge_dicts, ARRAY_ONLY_FUNCTIONS)
+from mitxgraders.helpers.calc.formatters import get_description
 
 class MatrixGrader(FormulaGrader):
     """
@@ -31,6 +32,22 @@ class MatrixGrader(FormulaGrader):
             A and positive integer k, A^-k is interpreted as (inverse(A))^k.
             If False, negative powers raise an error instead.
 
+        answer_shape_mismatch (dict): Describes how the default comparer_function
+            handles grading when student_input and stored answer have different
+            incompatible shapes. (For example, student_input is a vector, but
+            stored answer is a matrix.) Has keys:
+
+            is_raised (bool): If true, a ShapeError will be raised, otherwise
+                the student's input will be marked incorrect. In either case,
+                feedback is provided according to the `msg_detail` key.
+                Defaults to True.
+            msg_detail (None|'type'|'shape'): How detailed the feedback message
+                should be.
+                    None: No feedback is provided.
+                    'type': Type information about the expected/received objects
+                        is revealed (e.g., matrix vs vector)
+                    'shape': Type and shape information about the expected and
+                        received objects is revealed.
 
     """
 
@@ -45,8 +62,12 @@ class MatrixGrader(FormulaGrader):
         schema = super(MatrixGrader, self).schema_config
         return schema.extend({
             Required('max_array_dim', default=1): NonNegative(int),
+            Required('negative_powers', default=True): bool,
             Required('shape_errors', default=True): bool,
-            Required('negative_powers', default=True): bool
+            Required('answer_shape_mismatch', default={}): {
+                Required('is_raised', default=True): bool,
+                Required('msg_detail', default='type'): Any(None, 'type', 'shape')
+            }
         })
 
     def check_response(self, answer, student_input, **kwargs):
@@ -59,3 +80,31 @@ class MatrixGrader(FormulaGrader):
             else:
                 return {'ok': False, 'msg': err.message, 'grade_decimal': 0}
         return result
+
+    def default_equality_comparer(self, comparer_params, student_input, utils):
+        """
+        Default comparer function.
+
+        Assumes comparer_params is just the single expected answer wrapped in a list.
+        """
+        try:
+            return utils.within_tolerance(comparer_params[0], student_input)
+        except ShapeError as err:
+            is_raised = self.config['answer_shape_mismatch']['is_raised']
+            msg_detail = self.config['answer_shape_mismatch']['msg_detail']
+
+            if msg_detail is None:
+                msg = ''
+            else:
+                detailed = msg_detail == 'shape'
+                expected_shape = get_description(comparer_params[0], detailed=detailed)
+                received_shape = get_description(student_input, detailed=detailed)
+                if not detailed and expected_shape == received_shape:
+                    msg = ("Exepected answer to be a {0}, but input is a {1}."
+                           "of incorrect shape.".format(expected_shape, received_shape))
+                msg = ("Exepected answer to be a {0}, but input is a {1}."
+                       .format(expected_shape, received_shape))
+            if is_raised:
+                raise ShapeError(msg)
+            else:
+                return {'ok': False, 'grade_decimal': 0, 'msg': msg}

--- a/mitxgraders/helpers/calc/formatters.py
+++ b/mitxgraders/helpers/calc/formatters.py
@@ -1,0 +1,34 @@
+from numbers import Number
+from mitxgraders.helpers.calc.math_array import MathArray
+
+def get_description(obj, detailed=True):
+    """
+    Gets a student-facing description of obj.
+
+    Arguments:
+        obj: the object to describe
+        detailed (bool): for MathArray instances, whether to provide the shape
+            or only the shape name (scalar, vector, matrix, tensor)
+
+    Numbers return scalar:
+    >>> get_description(5)
+    'scalar'
+
+    MathArrays return their own description:
+    >>> get_description(MathArray([1, 2, 3]))
+    'vector of length 3'
+
+    Unless detailed=False, then only type is provided:
+    >>> get_description(MathArray([1, 2, 3]), detailed=False)
+    'vector'
+
+    Other objects return their class name:
+    >>> get_description("puppy")
+    'str'
+    """
+    if isinstance(obj, Number):
+        return 'scalar'
+    elif isinstance(obj, MathArray):
+        return obj.description if detailed else obj.shape_name
+    else:
+        return obj.__class__.__name__

--- a/mitxgraders/helpers/calc/mathfuncs.py
+++ b/mitxgraders/helpers/calc/mathfuncs.py
@@ -325,6 +325,8 @@ def within_tolerance(x, y, tolerance):
         y: number or array (np array_like)
         tolerance: Number or PercentageString
 
+    NOTE: Calculates x - y; may raise an error for incompatible shapes.
+
     Usage
     =====
 
@@ -348,14 +350,6 @@ def within_tolerance(x, y, tolerance):
     0.223607
     >>> within_tolerance(A, B, 0.25)
     True
-
-    If x - y raises a StudentFacingError, then subtraction of these types
-    is intentionally not supported and (x, y) are not within_tolerance:
-    >>> class Foo():
-    ...     def __sub__(self, other): raise StudentFacingError()
-    ...     def __rsub__(self, other): raise StudentFacingError()
-    >>> within_tolerance(0, Foo(), '1%')
-    False
     """
     # When used within graders, tolerance has already been
     # validated as a Number or PercentageString
@@ -364,10 +358,6 @@ def within_tolerance(x, y, tolerance):
         tolerance = tolerance.strip()
         tolerance = np.linalg.norm(x) * float(tolerance[:-1]) * 0.01
 
-    try:
-        difference = x - y
-    except StudentFacingError:
-        # Apparently, the answer and the student_input cannot be compared.
-        return False
+    difference = x - y
 
     return np.linalg.norm(difference) <= tolerance

--- a/mitxgraders/helpers/calc/specify_domain.py
+++ b/mitxgraders/helpers/calc/specify_domain.py
@@ -11,6 +11,7 @@ from mitxgraders.baseclasses import ObjectWithSchema
 from mitxgraders.helpers.calc.exceptions import DomainError
 from mitxgraders.helpers.calc.math_array import (
     MathArray, is_numberlike_array, is_square)
+from mitxgraders.helpers.calc.formatters import get_description
 
 def low_ordinal(n):
     """
@@ -23,29 +24,6 @@ def low_ordinal(n):
     """
     first_three = {1: '1st', 2: '2nd', 3: '3rd'}
     return first_three.get(n, '{0}th'.format(n))
-
-def get_description(obj):
-    """
-    Gets a student-facing description of obj.
-
-    Numbers return scalar:
-    >>> get_description(5)
-    'scalar'
-
-    MathArrays return their own description:
-    >>> get_description(MathArray([1, 2, 3]))
-    'vector of length 3'
-
-    Other objects return their class name:
-    >>> get_description("puppy")
-    'str'
-    """
-    if isinstance(obj, Number):
-        return 'scalar'
-    elif isinstance(obj, MathArray):
-        return obj.description
-    else:
-        return obj.__class__.__name__
 
 def get_shape_description(shape):
     """

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -555,7 +555,7 @@ def test_fg_debug_log():
     "Student Eval: (14.7111745179+2.08976636599j)<br/>\n"
     "Compare to:  [(14.711174517877566+2.0897663659937935j)]<br/>\n"
     "Comparer Function: <function default_equality_comparer at 0x...><br/>\n"
-    "Comparison Satisfied: True<br/>\n"
+    "Comparison Result: {{   'grade_decimal': 1.0, 'msg': '', 'ok': True}}<br/>\n"
     "<br/>\n"
     "<br/>\n"
     "==========================================<br/>\n"
@@ -572,7 +572,7 @@ def test_fg_debug_log():
     "Student Eval: (11.9397106851+2.78354600156j)<br/>\n"
     "Compare to:  [(11.939710685061661+2.7835460015641598j)]<br/>\n"
     "Comparer Function: <function default_equality_comparer at 0x...><br/>\n"
-    "Comparison Satisfied: True<br/>\n"
+    "Comparison Result: {{   'grade_decimal': 1.0, 'msg': '', 'ok': True}}<br/>\n"
     "</pre>"
     ).format(version=VERSION)
     assert result['msg'] == message

--- a/tests/formulagrader/test_matrixformulagrader.py
+++ b/tests/formulagrader/test_matrixformulagrader.py
@@ -142,8 +142,8 @@ def test_wrong_answer_type_error_messages():
             msg_detail='shape'
         )
     )
-    match = ('Exepected answer to be a matrix of shape \(rows: 1, cols: 3\), '
-             'but input is a vector of length 3.')
+    match = ('Expected answer to be a matrix of shape \(rows: 1, cols: 3\), '
+             'but input is a vector of length 3')
     with raises(ShapeError, match=match):
         grader(None, '[1, 2, 3]')
 
@@ -155,7 +155,7 @@ def test_wrong_answer_type_error_messages():
             msg_detail='type'
         )
     )
-    match = 'Exepected answer to be a matrix, but input is a vector'
+    match = 'Expected answer to be a matrix, but input is a vector'
     with raises(ShapeError, match=match):
         grader(None, '[1, 2, 3]')
 
@@ -167,9 +167,9 @@ def test_wrong_answer_type_error_messages():
             msg_detail='shape'
         )
     )
-    msg = ('Exepected answer to be a matrix of shape \(rows: 1, cols: 3\), '
-           'but input is a vector of length 3.')
-    grader(None, '[1, 2, 3]') == { 'ok': False, 'grade_decimal': 0, 'msg': msg }
+    msg = ('Expected answer to be a matrix of shape (rows: 1, cols: 3), '
+           'but input is a vector of length 3')
+    assert grader(None, '[1, 2, 3]') == { 'ok': False, 'grade_decimal': 0, 'msg': msg }
 
     grader = MatrixGrader(
         answers='[[1, 2, 3]]',
@@ -179,11 +179,11 @@ def test_wrong_answer_type_error_messages():
             msg_detail='type'
         )
     )
-    msg = 'Exepected answer to be a matrix, but input is a vector'
-    grader(None, '[1, 2, 3]') == { 'ok': False, 'grade_decimal': 0, 'msg': msg }
+    msg = 'Expected answer to be a matrix, but input is a vector'
+    assert grader(None, '[1, 2, 3]') == { 'ok': False, 'grade_decimal': 0, 'msg': msg }
 
-    msg = 'Exepected answer to be a matrix, but input is a matrix of incorrect shape'
-    grader(None, '[[1, 2, 3, 4]]') == { 'ok': False, 'grade_decimal': 0, 'msg': msg }
+    msg = 'Expected answer to be a matrix, but input is a matrix of incorrect shape'
+    assert grader(None, '[[1, 2, 3, 4]]') == { 'ok': False, 'grade_decimal': 0, 'msg': msg }
 
     grader = MatrixGrader(
         answers='[[1, 2, 3]]',
@@ -193,4 +193,4 @@ def test_wrong_answer_type_error_messages():
             msg_detail=None
         )
     )
-    grader(None, '[1, 2, 3]') == { 'ok': False, 'grade_decimal': 0, 'msg': '' }
+    assert grader(None, '[1, 2, 3]') == { 'ok': False, 'grade_decimal': 0, 'msg': '' }

--- a/tests/formulagrader/test_matrixformulagrader.py
+++ b/tests/formulagrader/test_matrixformulagrader.py
@@ -194,3 +194,36 @@ def test_wrong_answer_type_error_messages():
         )
     )
     assert grader(None, '[1, 2, 3]') == { 'ok': False, 'grade_decimal': 0, 'msg': '' }
+
+def test_wrong_answer_type_error_messages_with_scalars():
+    """
+    Check that answer shape errors are raised correctly when answer or student_input
+    is a scalar.
+
+    These are worth checking separately because the numbers do not have 'shape'
+    attributes.
+    """
+
+    grader = MatrixGrader(
+        answers='[1, 2, 3]',
+        max_array_dim=2,
+        answer_shape_mismatch=dict(
+            is_raised=True,
+            msg_detail='type'
+        )
+    )
+    match = 'Expected answer to be a vector, but input is a scalar'
+    with raises(ShapeError, match=match):
+        grader(None, '10')
+
+    grader = MatrixGrader(
+        answers='10',
+        max_array_dim=2,
+        answer_shape_mismatch=dict(
+            is_raised=True,
+            msg_detail='type'
+        )
+    )
+    match = 'Expected answer to be a scalar, but input is a vector'
+    with raises(ShapeError, match=match):
+        grader(None, '[1, 2, 3]')

--- a/tests/formulagrader/test_matrixformulagrader.py
+++ b/tests/formulagrader/test_matrixformulagrader.py
@@ -128,3 +128,69 @@ def test_matrix_inverses_raise_error_if_disabled():
     match='Negative matrix powers have been disabled.'
     with raises(MathArrayError, match=match):
         grader(None, 'A^3*A^-1')['ok']
+
+def test_wrong_answer_type_error_messages():
+    # Note: our convention is that single-row matrix and vectors cannot
+    # be compared, [[1, 2, 3]] are graded as different [1, 2, 3]
+    # (and, in particular, incomparable)
+
+    grader = MatrixGrader(
+        answers='[[1, 2, 3]]',
+        max_array_dim=2,
+        answer_shape_mismatch=dict(
+            is_raised=True,
+            msg_detail='shape'
+        )
+    )
+    match = ('Exepected answer to be a matrix of shape \(rows: 1, cols: 3\), '
+             'but input is a vector of length 3.')
+    with raises(ShapeError, match=match):
+        grader(None, '[1, 2, 3]')
+
+    grader = MatrixGrader(
+        answers='[[1, 2, 3]]',
+        max_array_dim=2,
+        answer_shape_mismatch=dict(
+            is_raised=True,
+            msg_detail='type'
+        )
+    )
+    match = 'Exepected answer to be a matrix, but input is a vector'
+    with raises(ShapeError, match=match):
+        grader(None, '[1, 2, 3]')
+
+    grader = MatrixGrader(
+        answers='[[1, 2, 3]]',
+        max_array_dim=2,
+        answer_shape_mismatch=dict(
+            is_raised=False,
+            msg_detail='shape'
+        )
+    )
+    msg = ('Exepected answer to be a matrix of shape \(rows: 1, cols: 3\), '
+           'but input is a vector of length 3.')
+    grader(None, '[1, 2, 3]') == { 'ok': False, 'grade_decimal': 0, 'msg': msg }
+
+    grader = MatrixGrader(
+        answers='[[1, 2, 3]]',
+        max_array_dim=2,
+        answer_shape_mismatch=dict(
+            is_raised=False,
+            msg_detail='type'
+        )
+    )
+    msg = 'Exepected answer to be a matrix, but input is a vector'
+    grader(None, '[1, 2, 3]') == { 'ok': False, 'grade_decimal': 0, 'msg': msg }
+
+    msg = 'Exepected answer to be a matrix, but input is a matrix of incorrect shape'
+    grader(None, '[[1, 2, 3, 4]]') == { 'ok': False, 'grade_decimal': 0, 'msg': msg }
+
+    grader = MatrixGrader(
+        answers='[[1, 2, 3]]',
+        max_array_dim=2,
+        answer_shape_mismatch=dict(
+            is_raised=False,
+            msg_detail=None
+        )
+    )
+    grader(None, '[1, 2, 3]') == { 'ok': False, 'grade_decimal': 0, 'msg': '' }

--- a/tests/formulagrader/test_matrixformulagrader.py
+++ b/tests/formulagrader/test_matrixformulagrader.py
@@ -228,3 +228,7 @@ def test_wrong_answer_type_error_messages_with_scalars():
     match = 'Expected answer to be a scalar, but input is a vector'
     with raises(InputTypeError, match=match):
         grader(None, '[1, 2, 3]')
+
+def test_validate_student_input_shape_edge_case():
+    with raises(AttributeError):
+        MatrixGrader.validate_student_input_shape([1, 2], (2,), 'type')

--- a/tests/formulagrader/test_matrixformulagrader.py
+++ b/tests/formulagrader/test_matrixformulagrader.py
@@ -1,6 +1,7 @@
 from pytest import raises
 import re
 from mitxgraders import (MatrixGrader, RealMatrices, RealVectors, ComplexRectangle)
+from mitxgraders.formulagrader.matrixgrader import InputTypeError
 from mitxgraders.helpers.calc.exceptions import (
     DomainError, MathArrayError,
     MathArrayShapeError as ShapeError, UnableToParse
@@ -144,7 +145,7 @@ def test_wrong_answer_type_error_messages():
     )
     match = ('Expected answer to be a matrix of shape \(rows: 1, cols: 3\), '
              'but input is a vector of length 3')
-    with raises(ShapeError, match=match):
+    with raises(InputTypeError, match=match):
         grader(None, '[1, 2, 3]')
 
     grader = MatrixGrader(
@@ -156,7 +157,7 @@ def test_wrong_answer_type_error_messages():
         )
     )
     match = 'Expected answer to be a matrix, but input is a vector'
-    with raises(ShapeError, match=match):
+    with raises(InputTypeError, match=match):
         grader(None, '[1, 2, 3]')
 
     grader = MatrixGrader(
@@ -213,7 +214,7 @@ def test_wrong_answer_type_error_messages_with_scalars():
         )
     )
     match = 'Expected answer to be a vector, but input is a scalar'
-    with raises(ShapeError, match=match):
+    with raises(InputTypeError, match=match):
         grader(None, '10')
 
     grader = MatrixGrader(
@@ -225,5 +226,5 @@ def test_wrong_answer_type_error_messages_with_scalars():
         )
     )
     match = 'Expected answer to be a scalar, but input is a vector'
-    with raises(ShapeError, match=match):
+    with raises(InputTypeError, match=match):
         grader(None, '[1, 2, 3]')


### PR DESCRIPTION
Provides configuration keys to customize what should happen when a student submits an answer to MatrixGrader that has the wrong shape.