### PR TITLE
Renaming tr to trace

### DIFF
--- a/MJxPrep.js
+++ b/MJxPrep.js
@@ -67,6 +67,7 @@ else {
             AM.newsymbol({input:"re", tag:"mi", output:"Re", tex:null, ttype:AM.TOKEN.UNARY, func:true});
             AM.newsymbol({input:"im", tag:"mi", output:"Im", tex:null, ttype:AM.TOKEN.UNARY, func:true});
             AM.newsymbol({input:"conj", tag:"mover", output:"\u00AF", tex:null, ttype:AM.TOKEN.UNARY, acc:true});
+            AM.newsymbol({input:"trace", tag:"mi", output:"Tr", tex:null, ttype:AM.TOKEN.UNARY, func:true});
 
             // Add special functions: fact and factorial
             AM.newsymbol({input:"fact", tag:"mo", output:"fact", tex:null, ttype:AM.TOKEN.UNARY, rewriteleftright:["","!"]});

--- a/mitxgraders/helpers/calc/mathfuncs.py
+++ b/mitxgraders/helpers/calc/mathfuncs.py
@@ -277,7 +277,7 @@ ARRAY_ONLY_FUNCTIONS = {
     'abs': array_abs,
     'trans': np.transpose,
     'det': has_one_square_input('det')(np.linalg.det),
-    'tr': has_one_square_input('tr')(np.trace),
+    'trace': has_one_square_input('trace')(np.trace),
     'ctrans': lambda x: np.conj(np.transpose(x)),
     'adj': lambda x: np.conj(np.transpose(x)),
     'cross': cross

--- a/tests/helpers/calc/test_mathfuncs.py
+++ b/tests/helpers/calc/test_mathfuncs.py
@@ -64,8 +64,8 @@ def test_det_and_tr_raise_error_if_not_square():
     with raises(DomainError, match=match):
         det(random_math_array((2, 3)))
 
-    tr = ARRAY_ONLY_FUNCTIONS['tr']
-    match = ("There was an error evaluating function tr\(...\)\n"
+    tr = ARRAY_ONLY_FUNCTIONS['trace']
+    match = ("There was an error evaluating function trace\(...\)\n"
              "1st input has an error: received a matrix of shape "
              "\(rows: 2, cols: 3\), expected a square matrix")
     with raises(DomainError, match=match):


### PR DESCRIPTION
Quick fix to rename `tr` to `trace`, so as not to confuse with `transpose`. Also added `trace` to javascript file. Documentation not updated, as this is part of a separate PR.