### PR TITLE
rewrite expression parser/evaluator

### DIFF
--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -734,7 +734,7 @@ class FormulaGrader(ItemGrader):
         Arguments
         =========
         - scoped_eval (func): a unary function to evaluate math expressions.
-            Same keyword arguments as calc.py's evaluator, but with appropriate
+            Same keyword arguments as calc's evaluator, but with appropriate
             default variables, functions, suffixes
         - comparer_params ([str]): unevaluated expressions
         - siblings_eval (dict): evaluated expressions

--- a/mitxgraders/helpers/calc/__init__.py
+++ b/mitxgraders/helpers/calc/__init__.py
@@ -3,7 +3,7 @@ calc module
 
 Exports frequently used objects for convenience
 """
-from mitxgraders.helpers.calc.calc import evaluator
+from mitxgraders.helpers.calc.expressions import evaluator, PARSER
 from mitxgraders.helpers.calc.mathfuncs import (
     DEFAULT_VARIABLES,
     DEFAULT_FUNCTIONS,

--- a/mitxgraders/helpers/calc/exceptions.py
+++ b/mitxgraders/helpers/calc/exceptions.py
@@ -1,7 +1,7 @@
 from mitxgraders.exceptions import StudentFacingError
 
 class CalcError(StudentFacingError):
-    """Base class for errors originating in calc.py"""
+    """Base class for errors originating in calc module"""
     pass
 
 class UndefinedVariable(CalcError):

--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -414,7 +414,7 @@ class MathParser(object):
         #   subscripts (optional):
         #       any combination of alphanumeric and underscores
         #   lower_indices (optional):
-        #       Of form "_{(-)<alaphnumeric>}"
+        #       Of form "_{(-)<alphanumeric>}"
         #   upper_indices (optional):
         #       Of form "^{(-)<alphanumeric>}"
         #   tail (optional):
@@ -608,7 +608,7 @@ class MathExpression(object):
         bad_suffixes = set(suff for suff in self.suffixes_used if suff not in suffixes)
         if bad_suffixes:
             bad_suff_names = ', '.join(sorted(bad_suffixes))
-            message = "Invalid Input: {} not permitted directly after a number."
+            message = "Invalid Input: {} not permitted directly after a number"
 
             # Check to see if there is a corresponding variable name
             if any(suff in variables for suff in bad_suffixes):
@@ -627,6 +627,21 @@ class MathExpression(object):
             raise UndefinedFunction(message.format(bad_suff_names))
 
     def eval(self, variables, functions, suffixes, allow_inf=False):
+        """
+        Numerically evaluate a MathExpression's tree, returning a tuple of the
+        numeric result and evaluation metadata.
+
+        Also recasts some errors as CalcExceptions (which are student-facing).
+
+        Arguments:
+            variables (dict): maps variable names to values
+            functions (dict): maps function names to values
+            suffixes (dict): maps suffix names to values
+            allow_inf (bool): If true, any node evaluating to inf will throw
+                a CalcOverflowError
+
+        See class-level docstring for example usage.
+        """
         self.check_scope(variables, functions, suffixes)
 
         # metadata_dict['max_array_dim_used'] is updated by eval_array
@@ -670,8 +685,8 @@ class MathExpression(object):
     @staticmethod
     def eval_node(node, actions, allow_inf):
         """
-        Recursively evaluates a node, calling itself on the nodes children. Delegates to one of the provided actions,
-        passing evaluated child nodes as arguments.
+        Recursively evaluates a node, calling itself on the node's children.
+        Delegates to one of the provided actions, passing evaluated child nodes as arguments.
         """
 
         if not isinstance(node, ParseResults):
@@ -1096,6 +1111,7 @@ class MathExpression(object):
         return result
 
 PARSER = MathParser()
+
 def evaluator(formula,
               variables=DEFAULT_VARIABLES,
               functions=DEFAULT_FUNCTIONS,

--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -1020,10 +1020,10 @@ class MathExpression(object):
         >>> MathExpression.eval_parallel([1,1])
         0.5
         >>> MathExpression.eval_parallel([1,0])
-        nan
+        0
         """
         if 0 in parse_result:
-            return float('nan') # Thinking about circuits, should x || 0 = 0 ?
+            return 0
         reciprocals = [1. / num for num in parse_result]
         return 1. / sum(reciprocals)
 

--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -392,7 +392,6 @@ class MathParser(object):
             Combine(
                 inner_number +
                 Optional(CaselessLiteral("E") + Optional(plus_minus) + number_part),
-                adjacent=False
             )("num")
             + Optional(suffix)("suffix")
         )("number")

--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -3,7 +3,7 @@ expressions.py
 
 Defines classes to parse and evaluate mathematical expressions. Implements
 similar functionality and API as edX's calc.py, but re-written with enhancements
-and to betterseparate parsing and evaluation.
+and to better separate parsing and evaluation.
 
 To evaluate a mathematical expression like '2^a + [x, 2]*[y, 4]', we proceed
 in two steps:
@@ -1005,7 +1005,7 @@ class MathExpression(object):
         """
         Operator associated with parallel resistors (it's commutative).
 
-        Return NaN if there is a zero among the inputs.
+        Return 0 if there is a zero among the inputs.
 
         Arguments:
             parse_result: A list of numbers to combine appropriately

--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -1,11 +1,37 @@
 """
 calc.py
 
-Parser and evaluator for mathematical expressions.
+Defines classes to parse and evaluate mathematical expressions.
 
-Uses pyparsing to parse. Main function is evaluator().
+To evaluate a mathematical expression like '2^a + [x, 2]*[y, 4]', we proceed
+in two steps:
 
-Heavily modified from the edX calc.py
+    1. First, the expression is parsed into a tree
+
+                               /--- NUMBER --- '2'
+                 /--- POWER ---
+                /              \--- VARIABLE --- 'a'
+               /
+              /
+        SUM --  -- OP -- '+'
+              \                                   /--- VARIABLE --- 'x'
+               \                    /--- ARRAY ---
+                \                  /              \--- NUMBER --- '2'
+                 \                /
+                  \--- PRODUCT ---  -- OP -- '*'
+                                  \
+                                   \              /--- VARIABLE --- 'y'
+                                    \--- ARRAY ---
+                                                  \--- NUMBER --- '4'
+
+    2. Next, the tree is evaluated from the leaves upwards.
+
+This file defines two main classes:
+ - MathParser, used to parse mathematical strings into a tree
+ - MathExpression, holds the parse tree for a given mathematical expression
+   and can be used to evaluate the tree with a given scope.
+and a function:
+ - evaluator: a convenience function that parses and evaluates strings.
 """
 from __future__ import division
 import copy
@@ -202,146 +228,6 @@ class BracketValidator(object):
         # edX renders it like a highlighter, with yellowish background.
         return formula[:index] + '<mark>{}</mark>'.format(char) + formula[index+1:]
 
-class ParserCache(object):
-    """Stores the parser trees for formula strings for reuse"""
-
-    def __init__(self):
-        """Initializes the cache"""
-        self.cache = {}
-
-    def get_parser(self, formula, suffixes):
-        """Get a FormulaParser object for a given formula"""
-        # Check the formula for matching parentheses
-        BracketValidator.validate(formula)
-
-        # Strip out any whitespace, so that two otherwise-equivalent formulas are treated
-        # the same
-        stripformula = formula.replace(" ", "")
-
-        # Construct the key
-        suffixstr = ""
-        for key in suffixes:
-            suffixstr += key
-        key = (stripformula, ''.join(sorted(suffixstr)))
-
-        # Check if it's in the cache
-        parser = self.cache.get(key, None)
-        if parser is not None:
-            return parser
-
-        # It's not, so construct it
-        parser = FormulaParser(stripformula, suffixes)
-        try:
-            parser.parse_algebra()
-        except ParseException:
-            msg = "Invalid Input: Could not parse '{}' as a formula"
-            raise UnableToParse(msg.format(formula))
-
-        # Save it for later use before returning it
-        self.cache[key] = parser
-        return parser
-
-# The global parser cache
-parsercache = ParserCache()
-
-ScopeUsage = namedtuple('ScopeUSage', ['variables', 'functions', 'suffixes'])
-
-def evaluator(formula,
-              variables=DEFAULT_VARIABLES,
-              functions=DEFAULT_FUNCTIONS,
-              suffixes=DEFAULT_SUFFIXES,
-              max_array_dim=None,
-              allow_inf=False):
-    """
-    Evaluate an expression; that is, take a string of math and return a float.
-
-    Arguments
-    =========
-    - formula (str): The formula to be evaluated
-    Pass a scope consisting of variables, functions, and suffixes:
-    - variables (dict): maps strings to variable values, defaults to DEFAULT_VARIABLES
-    - functions (dict): maps strings to functions, defaults to DEFAULT_FUNCTIONS
-    - suffixes (dict): maps strings to suffix values, defaults to DEFAULT_SUFFIXES
-    Also:
-    - max_array_dim: Maximum dimension of MathArrays
-    - allow_inf: Whether to raise an error if the evaluator encounters an infinity
-
-    NOTE: Everything is case sensitive (this is different to edX!)
-
-    Usage
-    =====
-    Evaluates the formula and records usage of functions/variables/suffixes:
-    >>> result = evaluator("1+1", {}, {}, {})
-    >>> expected = ( 2.0 , ScopeUsage(
-    ...     variables=set(),
-    ...     functions=set(),
-    ...     suffixes=set()
-    ... ))
-    >>> result == expected
-    True
-    >>> result = evaluator("square(x) + 5k",
-    ...     variables={'x':5, 'y': 10},
-    ...     functions={'square': lambda x: x**2, 'cube': lambda x: x**3},
-    ...     suffixes={'%': 0.01, 'k': 1000  })
-    >>> expected = ( 5025.0 , ScopeUsage(
-    ...     variables=set(['x']),
-    ...     functions=set(['square']),
-    ...     suffixes=set(['k'])
-    ... ))
-    >>> result == expected
-    True
-
-    Empty submissions evaluate to nan:
-    >>> evaluator("")[0]
-    nan
-
-    Submissions that generate infinities will raise an error:
-    >>> evaluator("inf", variables={'inf': float('inf')})[0]  # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-    CalcOverflowError: Numerical overflow occurred. Does your expression generate ...
-
-    Unless you specify that infinity is ok:
-    >>> evaluator("inf", variables={'inf': float('inf')}, allow_inf=True)[0]
-    inf
-    """
-
-    empty_usage = ScopeUsage(set(), set(), set())
-    if formula is None:
-        # No need to go further.
-        return float('nan'), empty_usage
-    formula = formula.strip()
-    if formula == "":
-        # No need to go further.
-        return float('nan'), empty_usage
-
-    # Parse the tree
-    math_interpreter = parsercache.get_parser(formula, suffixes)
-
-    # Set the variables and functions
-    math_interpreter.set_vars_funcs(variables, functions)
-
-    # Check the variables and functions
-    math_interpreter.check_variables()
-
-    # Perform the evaluation
-    result = math_interpreter.evaluate(allow_inf)
-
-    # Were vectors/matrices/tensors used when they shouldn't have been?
-    if max_array_dim is not None and math_interpreter.max_array_dim_used > max_array_dim:
-        if max_array_dim == 0:
-            msg = "Vector and matrix expressions have been forbidden in this entry."
-        elif max_array_dim == 1:
-            msg = "Matrix expressions have been forbidden in this entry."
-        else:
-            msg = "Tensor expressions have been forbidden in this entry."
-        raise UnableToParse(msg)
-
-    # Return the result of the evaluation, as well as the set of functions used
-    usage = ScopeUsage(variables=math_interpreter.variables_used,
-                       functions=math_interpreter.functions_used,
-                       suffixes=math_interpreter.suffixes_used)
-    return result, usage
-
 def cast_np_numeric_as_builtin(obj, map_across_lists=False):
     """
     Cast numpy numeric types as builtin python types.
@@ -381,57 +267,69 @@ def cast_np_numeric_as_builtin(obj, map_across_lists=False):
                 for item in obj]
     return obj
 
-class FormulaParser(object):
+class MathParser(object):
     """
-    Parses a mathematical expression into a tree that can subsequently be evaluated
-    against given dictionaries of variables and functions.
-    """
-    def __init__(self, math_expr, suffixes):
-        """
-        Create the ParseAugmenter for a given math expression string.
+    Parses mathematical expressions into trees and caches the result.
+    Expression trees are returned as MathExpression objects, which can then
+    be evaluated.
 
-        Do the parsing later, when called like `OBJ.parse_algebra()`.
-        """
-        self.math_expr = math_expr
-        self.tree = None
+    Usage
+    =====
+    >>> new_parser = MathParser()
+    >>> parsed = new_parser.parse('2*x + 5')
+    >>> isinstance(parsed, MathExpression)
+    True
+    >>> parsed
+    <BLANKLINE>
+    <sum>
+      <product>
+        <number>
+          <num>2</num>
+        </number>
+        <op>*</op>
+        <variable>
+          <varname>x</varname>
+        </variable>
+      </product>
+      <op>+</op>
+      <number>
+        <num>5</num>
+      </number>
+    </sum>
+    """
+
+    def __init__(self):
+        self.cache = {}
+        self.grammar = self.get_grammar()
+
+        # Internal storage that is reset at the end of calls to MathParser.parse
         self.variables_used = set()
         self.functions_used = set()
         self.suffixes_used = set()
         self.max_array_dim_used = 0
-        self.suffixes = suffixes
-        self.actions = {
-            'number': self.eval_number,
-            'variable': self.eval_variable,
-            'arguments': lambda tokens: tokens,
-            'function': self.eval_function,
-            'array': self.eval_array,
-            'power': self.eval_power,
-            'negation': self.eval_negation,
-            'parallel': self.eval_parallel,
-            'product': self.eval_product,
-            'sum': self.eval_sum,
-            'parentheses': lambda tokens: tokens[0]  # just get the unique child
-        }
-        self.vars = {}
-        self.functions = {}
+
+    def reset_storage(self):
+        self.variables_used = set()
+        self.functions_used = set()
+        self.suffixes_used = set()
 
     def variable_parse_action(self, tokens):
         """
-        When a variable is recognized, store it in `variables_used`.
+        When pyparsing encounters a variable, store it in variables_used
         """
         self.variables_used.add(tokens[0][0])
 
     def function_parse_action(self, tokens):
         """
-        When a function is recognized, store it in `functions_used`.
+        When pyparsing encounters a function, store it in variables_used
         """
         self.functions_used.add(tokens[0][0])
 
     def suffix_parse_action(self, tokens):
         """
-        When a suffix is recognized, store it in `suffixes_used`.
+        When pyparsing encounters a suffix, store it in variables_used
         """
-        self.suffixes_used.add(tokens[0][0])
+        self.suffixes_used.add(tokens[0])
 
     @staticmethod
     def group_if_multiple(name):
@@ -447,17 +345,17 @@ class FormulaParser(object):
 
         return _parse_action
 
-    def parse_algebra(self):
+    # TODO: Possibly refactor this into separate pieces;
+    # example: accessing the variable name parser could be useful in a few places
+    def get_grammar(self):
         """
-        Parse an algebraic expression into a tree.
+        Defines our grammar for mathematical expressions.
 
-        Store a `pyparsing.ParseResult` in `self.tree` with proper groupings to
-        reflect parenthesis and order of operations. Leave all operators in the
-        tree and do not parse any strings of numbers into their float versions.
-
-        To visualize the tree for debugging purposes, use
-            FormulaParser.dump_parse_result(parse_result)
+        Possibly helpful:
+            - BNF form of context-free grammar https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form
+            - Some pyparsing docs http://infohost.nmt.edu/~shipman/soft/pyparsing/web/index.html
         """
+
         # Define + and -
         plus = Literal("+")
         minus = Literal("-")
@@ -469,16 +367,16 @@ class FormulaParser(object):
                                |
                                ("." + number_part))
         # Combine() joints the matching parts together in a single token,
-        # and requires that the matching parts be contiguous
+        # and requires that the matching parts be contiguous (no spaces)
 
         # Define our suffixes
-        suffix = MatchFirst(Literal(k) for k in self.suffixes.keys())
+        suffix = Word(alphas + '%')
         suffix.setParseAction(self.suffix_parse_action)
 
-        # Construct a number as a group consisting of a text string (num) and an optional
-        # suffix num can include a decimal number and numerical exponent, and can be
+        # Construct number as a group consisting of a text string ("num") and an optional suffix.
+        # num can include a decimal number and numerical exponent, and can be
         # converted to a number using float()
-        # suffix is the suffix string that matches one of our suffixes
+        # suffix may contain alphas or %
         # Spaces are ignored inside numbers
         # Group wraps everything up into its own ParseResults object when parsing
         number = Group(
@@ -490,7 +388,7 @@ class FormulaParser(object):
             + Optional(suffix)("suffix")
         )("number")
         # Note that calling ("name") on the end of a parser is equivalent to calling
-        # parser.setResultsName, which is used to pulling that result out of a parsed
+        # parser.setResultsName, which is used to pull that result out of a parsed
         # expression like a dictionary.
 
         # Construct variable and function names
@@ -509,20 +407,20 @@ class FormulaParser(object):
         #   lower_indices (optional):
         #       Of form "_{(-)<alaphnumeric>}"
         #   upper_indices (optional):
-        #       Of form "^{(-)<alaphnumeric>}"
+        #       Of form "^{(-)<alphanumeric>}"
         #   tail (optional):
         #       any number of primes
         name = Combine(front +
                        Optional(subscripts |
                                 (Optional(lower_indices) + Optional(upper_indices))
-                                ) +
+                               ) +
                        ZeroOrMore("'"))
         # Define a variable as a pyparsing result that contains one object name
         variable = Group(name("varname"))("variable")
         variable.setParseAction(self.variable_parse_action)
 
-        # Predefine recursive variable expr
-        expr = Forward()
+        # initialize recursive grammar
+        expression = Forward()
 
         # Construct functions as consisting of funcname and arguments as
         # funcname(arguments)
@@ -530,31 +428,30 @@ class FormulaParser(object):
         # Must have at least 1 argument
         function = Group(name("funcname") +
                          Suppress("(") +
-                         Group(delimitedList(expr))("arguments") +
+                         Group(delimitedList(expression))("arguments") +
                          Suppress(")")
-                         )("function")
+                        )("function")
         function.setParseAction(self.function_parse_action)
 
         # Define parentheses
         parentheses = Group(Suppress("(") +
-                            expr +
+                            expression +
                             Suppress(")"))('parentheses')
 
         # Define arrays
         array = Group(Suppress("[") +
-                      delimitedList(expr) +
+                      delimitedList(expression) +
                       Suppress("]"))("array")
 
-        # Define an atomic unit as an expression that evaluates directly to a number
-        # without the use of binary operations (assuming all children have been evaluated).
+        # atomic units evaluate directly to number or array without binary operations
         atom = number | function | variable | parentheses | array
 
-        # The following are in order of operational precedence
+        # Define operations in order of precedence
         # Define exponentiation, possibly including negative powers
         power = atom + ZeroOrMore(Suppress("^") + Optional(minus)("op") + atom)
         power.addParseAction(self.group_if_multiple('power'))
 
-        # Define negation (eg, in 5*-3 --> we need to evaluate the -3 first)
+        # Define negation (e.g., in 5*-3 --> we need to evaluate the -3 first)
         # Negation in powers is handled separately
         # This has been arbitrarily assigned a higher precedence than parallel
         negation = Optional(minus)("op") + power
@@ -575,82 +472,93 @@ class FormulaParser(object):
         sumdiff.addParseAction(self.group_if_multiple('sum'))
 
         # Close the recursion
-        expr << sumdiff
+        expression << sumdiff
 
-        # Save the resulting tree
-        self.tree = (expr + stringEnd).parseString(self.math_expr)[0]
+        return expression + stringEnd
 
-    def dump_parse_result(self):  # pragma: no cover
-        """Pretty-print an XML version of the parse_result for debug purposes"""
-        print(self.tree.asXML())
-
-    def set_vars_funcs(self, variables=None, functions=None):
-        """Stores the given dictionaries of variables and functions for future use"""
-        self.vars = variables if variables else {}
-        self.functions = functions if functions else {}
-
-    def evaluate(self, allow_inf):
+    def raw_parse(self, expression):
         """
-        Recursively evaluate `self.tree` and return the result.
+        Try to parse a string and cache the result. ALWAYS clears storage.
         """
-        def handle_node(node):
-            """
-            Return the result representing the node, using recursion.
-
-            Call the appropriate action from self.actions for this node. As its inputs,
-            feed it the output of `handle_node` for each child node.
-            """
-            if not isinstance(node, ParseResults):
-                # Entry is either a (python) number or a string.
-                # Return it directly to the next level up.
-                return cast_np_numeric_as_builtin(node)
-
-            node_name = node.getName()
-            if node_name not in self.actions:  # pragma: no cover
-                raise Exception(u"Unknown branch name '{}'".format(node_name))
-
-            action = self.actions[node_name]
-            handled_kids = [handle_node(k) for k in node]
-
-            # Check for nan
-            if any(np.isnan(item) for item in handled_kids if isinstance(item, float)):
-                return float('nan')
-
-            # Compute the result of this node
-            result = action(handled_kids)
-
-            # All actions convert the input to a number, array, or list.
-            # (Only self.actions['arguments'] returns a list.)
-            as_list = result if isinstance(result, list) else [result]
-
-            # Check if there were any infinities or nan
-            if not allow_inf and any(np.any(np.isinf(r)) for r in as_list):
-                raise CalcOverflowError("Numerical overflow occurred. Does your expression "
-                                        "generate very large numbers?")
-            if any(np.any(np.isnan(r)) for r in as_list):
-                return float('nan')
-
-            return cast_np_numeric_as_builtin(result, map_across_lists=True)
-
-        # Find the value of the entire tree
-        # Catch math errors that may arise
         try:
-            result = handle_node(self.tree)
-        except OverflowError:
-            raise CalcOverflowError("Numerical overflow occurred. "
-                                    "Does your input generate very large numbers?")
-        except ZeroDivisionError:
-            raise CalcZeroDivisionError("Division by zero occurred. "
-                                        "Check your input's denominators.")
+            BracketValidator.validate(expression)
+            tree = self.grammar.parseString(expression)[0]
+            parsed = MathExpression(expression,
+                                    tree,
+                                    self.variables_used,
+                                    self.functions_used,
+                                    self.suffixes_used)
+        except:
+            raise
+        finally:
+            self.reset_storage()
 
-        return result
+        return parsed
 
-    def check_variables(self):
+    def parse(self, expression):
         """
-        Confirm that all the variables and functions used in the tree are defined.
+        If expression is in parser cache, return cached result, otherwise
+        delegate to raw_parse.
         """
-        bad_vars = set(var for var in self.variables_used
-                       if var not in self.vars)
+        expression_no_whitespace = expression.replace(' ', '')
+        cache_key = expression_no_whitespace
+        if expression_no_whitespace in self.cache:
+            return self.cache[cache_key]
+
+        try:
+            parsed = self.raw_parse(expression)
+        except ParseException:
+            msg = "Invalid Input: Could not parse '{}' as a formula"
+            raise UnableToParse(msg.format(expression))
+
+        self.cache[cache_key] = parsed
+        return parsed
+
+EvalMetaData = namedtuple('EvalMetaData', ['variables_used', 'functions_used', 'suffixes_used', 'max_array_dim_used'])
+class MathExpression(object):
+    """
+    Holds the parse tree for mathematical expression; returned by MathParser.
+
+    Attributes:
+        - expression (str): the original string that generated this parse tree
+        - variables_used (set)
+        - functions_used (set)
+        - suffixes_used (set)
+
+    Methods:
+        - eval(variables, functions, suffixes, allow_inf)
+
+    EXAMPLE:
+    ========
+    >>> new_parser = MathParser()
+    >>> expression = new_parser.parse('2^a + [x, 2]*[y, f(2, 3)] + 3%')
+    >>> variables = { 'a': 2, 'x': 3, 'y': 4 }
+    >>> functions = { 'f': lambda x, y: x**y }
+    >>> suffixes = { '%': 0.01 }
+    >>> result, meta = expression.eval(variables, functions, suffixes)
+    >>> result
+    32.03
+
+    """
+
+    def __init__(self, expression, tree, variables_used, functions_used, suffixes_used):
+        self.expression = expression
+        self.variables_used = variables_used
+        self.functions_used = functions_used
+        self.suffixes_used = suffixes_used
+        self.tree = tree
+
+    def __str__(self):
+        return self.tree.asXML()
+    def __repr__(self):
+        return self.__str__()
+
+    def check_scope(self, variables, functions, suffixes):
+        """
+        Confirm that all variables, functions, suffixes used in the tree are
+        provided. Tries to provide helpful StudentFacingError if not.
+        """
+        bad_vars = set(var for var in self.variables_used if var not in variables)
         if bad_vars:
             message = "Invalid Input: {} not permitted in answer as a variable"
             varnames = ", ".join(sorted(bad_vars))
@@ -658,7 +566,7 @@ class FormulaParser(object):
             # Check to see if there is a different case version of the variable
             caselist = set()
             for var2 in bad_vars:
-                for var1 in self.vars:
+                for var1 in variables:
                     if var1.lower() == var2.lower():
                         caselist.add(var1)
             if len(caselist) > 0:
@@ -667,20 +575,19 @@ class FormulaParser(object):
 
             raise UndefinedVariable(message.format(varnames))
 
-        bad_funcs = set(func for func in self.functions_used
-                        if func not in self.functions)
+        bad_funcs = set(func for func in self.functions_used if func not in functions)
         if bad_funcs:
             funcnames = ', '.join(sorted(bad_funcs))
             message = "Invalid Input: {} not permitted in answer as a function"
 
             # Check to see if there is a corresponding variable name
-            if any(func in self.vars for func in bad_funcs):
+            if any(func in variables for func in bad_funcs):
                 message += " (did you forget to use * for multiplication?)"
 
             # Check to see if there is a different case version of the function
             caselist = set()
             for func2 in bad_funcs:
-                for func1 in self.functions:
+                for func1 in functions:
                     if func2.lower() == func1.lower():
                         caselist.add(func1)
             if len(caselist) > 0:
@@ -689,11 +596,109 @@ class FormulaParser(object):
 
             raise UndefinedFunction(message.format(funcnames))
 
+        bad_suffixes = set(suff for suff in self.suffixes_used if suff not in suffixes)
+        if bad_suffixes:
+            bad_suff_names = ', '.join(sorted(bad_suffixes))
+            message = "Invalid Input: {} not permitted directly after a number."
+
+            # Check to see if there is a corresponding variable name
+            if any(suff in variables for suff in bad_suffixes):
+                message += " (did you forget to use * for multiplication?)"
+
+            # Check to see if there is a different case version of the suffix
+            caselist = set()
+            for suff2 in bad_suffixes:
+                for suff1 in suffixes:
+                    if suff2.lower() == suff1.lower():
+                        caselist.add(suff1)
+            if len(caselist) > 0:
+                betternames = ', '.join(sorted(caselist))
+                message += " (did you mean " + betternames + "?)"
+
+            raise UndefinedFunction(message.format(bad_suff_names))
+
+    def eval(self, variables, functions, suffixes, allow_inf=False):
+        self.check_scope(variables, functions, suffixes)
+
+        # metadata_dict['max_array_dim_used'] is updated by eval_array
+        metadata_dict = {'max_array_dim_used': 0}
+        actions = {
+            'number': lambda parse_result: self.eval_number(parse_result, suffixes),
+            'variable': lambda parse_result: self.eval_variable(parse_result, variables),
+            'arguments': lambda tokens: tokens,
+            'function': lambda parse_result: self.eval_function(parse_result, functions),
+            'array': lambda parse_result: self.eval_array(parse_result, metadata_dict),
+            'power': self.eval_power,
+            'negation': self.eval_negation,
+            'parallel': self.eval_parallel,
+            'product': self.eval_product,
+            'sum': self.eval_sum,
+            'parentheses': lambda tokens: tokens[0]  # just get the unique child
+        }
+
+        # Find the value of the entire tree
+        # Catch math errors that may arise
+        try:
+            result = self.eval_node(self.tree, actions, allow_inf)
+            # set metadata after metadata_dict has been mutated
+            metadata = EvalMetaData(variables_used=self.variables_used,
+                                         functions_used=self.functions_used,
+                                         suffixes_used=self.suffixes_used,
+                                         max_array_dim_used=metadata_dict['max_array_dim_used'])
+        except OverflowError:
+            raise CalcOverflowError("Numerical overflow occurred. "
+                                    "Does your input generate very large numbers?")
+        except ZeroDivisionError:
+            raise CalcZeroDivisionError("Division by zero occurred. "
+                                        "Check your input's denominators.")
+
+        return result, metadata
+
     # The following functions define evaluation actions, which are run on lists
     # of results from each parse component. They convert the strings and (previously
     # calculated) numbers into the number that component represents.
 
-    def eval_number(self, parse_result):
+    @staticmethod
+    def eval_node(node, actions, allow_inf):
+        """
+        Recursively evaluates a node, calling itself on the nodes children. Delegates to one of the provided actions,
+        passing evaluated child nodes as arguments.
+        """
+
+        if not isinstance(node, ParseResults):
+            # We have a leaf, do not recurse. Return it directly.
+            # Entry is either a (python) number or a string.
+            return cast_np_numeric_as_builtin(node)
+
+        node_name = node.getName()
+        if node_name not in actions:  # pragma: no cover
+            raise ValueError(u"Unknown branch name '{}'".format(node_name))
+
+        evaluated_children = [MathExpression.eval_node(child, actions, allow_inf) for child in node]
+
+        # Check for nan
+        if any(np.isnan(item) for item in evaluated_children if isinstance(item, float)):
+            return float('nan')
+
+        # Compute the result of this node
+        action = actions[node_name]
+        result = action(evaluated_children)
+
+        # All actions convert the input to a number, array, or list.
+        # (Only self.actions['arguments'] returns a list.)
+        as_list = result if isinstance(result, list) else [result]
+
+        # Check if there were any infinities or nan
+        if not allow_inf and any(np.any(np.isinf(r)) for r in as_list):
+            raise CalcOverflowError("Numerical overflow occurred. Does your expression "
+                                    "generate very large numbers?")
+        if any(np.any(np.isnan(r)) for r in as_list):
+            return float('nan')
+
+        return cast_np_numeric_as_builtin(result, map_across_lists=True)
+
+    @staticmethod
+    def eval_number(parse_result, suffixes):
         """
         Create a float out of the input, applying a suffix if there is one
 
@@ -702,30 +707,31 @@ class FormulaParser(object):
 
         Usage
         =====
-        >>> parser = FormulaParser("1", {"%": 0.01})
-        >>> parser.eval_number(['7.13e3'])
+        >>> MathExpression.eval_number(['7.13e3'], {})
         7130.0
-        >>> parser.eval_number(['5', '%'])
+        >>> MathExpression.eval_number(['5', '%'], {'%': 0.01})
         0.05
         """
         result = float(parse_result[0])
         if len(parse_result) == 2:
-            result *= self.suffixes[parse_result[1]]
+            result *= suffixes[parse_result[1]]
         return result
 
-    def eval_variable(self, parse_result):
+    @staticmethod
+    def eval_variable(parse_result, variables):
         """
         Returns a copy of the variable in self.vars
 
         We return a copy so that nothing in self.vars is mutated.
 
-        NOTE: The variable's class must implement a __copy__ method.
+        NOTE: The variable's value's class must implement a __copy__ method.
             (numpy ndarrays do implement this method)
         """
-        variable = self.vars[parse_result[0]]
-        return copy.copy(variable)
+        value = variables[parse_result[0]]
+        return copy.copy(value)
 
-    def eval_function(self, parse_result):
+    @staticmethod
+    def eval_function(parse_result, functions):
         """
         Evaluates a function
 
@@ -736,19 +742,17 @@ class FormulaParser(object):
         =====
         Instantiate a parser and some functions:
         >>> import math
-        >>> parser = FormulaParser("1", {})
-        >>> parser.set_vars_funcs(functions={"sin": math.sin, "cos": math.cos})
+        >>> functions = {"sin": math.sin, "cos": math.cos}
 
         Single variable functions work:
-        >>> parser.eval_function(['sin', [0]])
+        >>> MathExpression.eval_function(['sin', [0]], functions)
         0.0
-        >>> parser.eval_function(['cos', [0]])
+        >>> MathExpression.eval_function(['cos', [0]], functions)
         1.0
 
         So do multivariable functions:
         >>> def h(x, y): return x + y
-        >>> parser.set_vars_funcs(functions={"h": h})
-        >>> parser.eval_function(['h', [1, 2]])
+        >>> MathExpression.eval_function(['h', [1, 2]], {"h": h})
         3
 
         Validation:
@@ -757,8 +761,7 @@ class FormulaParser(object):
         validate that the correct number of arguments are passed:
 
         >>> def h(x, y): return x + y
-        >>> parser.set_vars_funcs(functions={"h": h})
-        >>> parser.eval_function(['h', [1, 2, 3]])
+        >>> MathExpression.eval_function(['h', [1, 2, 3]], {"h": h})
         Traceback (most recent call last):
         ArgumentError: Wrong number of arguments passed to h. Expected 2, received 3.
 
@@ -772,18 +775,17 @@ class FormulaParser(object):
         ...         raise StudentFacingError('I need two inputs!')
         ...     return args[0]*args[1]
         >>> g.validated = True
-        >>> parser.set_vars_funcs(functions={"g": g})
-        >>> parser.eval_function(['g', [1]])
+        >>> MathExpression.eval_function(['g', [1]], {"g": g})
         Traceback (most recent call last):
         StudentFacingError: I need two inputs!
         """
         # Obtain the function and arguments
         name, args = parse_result
-        func = self.functions[name]
+        func = functions[name]
 
         # If function does not do its own validation, try and validate here.
         if not getattr(func, 'validated', False):
-            FormulaParser.validate_function_call(func, name, args)
+            MathExpression.validate_function_call(func, name, args)
 
         # Try to call the function
         try:
@@ -820,60 +822,83 @@ class FormulaParser(object):
             raise ArgumentError(msg.format(func=name, num=expected, num2=num_args))
         return True
 
-    def eval_array(self, parse_result):
+    @staticmethod
+    def eval_array(parse_result, metadata_dict):
         """
         Takes in a list of evaluated expressions and returns it as a MathArray.
+        May mutate metadata_dict.
 
         If passed a list of numpy arrays, generates a matrix/tensor/etc.
 
         Arguments:
             parse_result: A list containing each element of the array
+            metadata_dict: A dictionary with key 'max_array_dim_used', whose
+                value should be an integer. If the result of eval_array has higher
+                dimension than 'max_array_dim_used', this value will be updated.
 
         Usage
         =====
-        Returns MathArray instances:
-        >>> parser = FormulaParser("1", {}) # fake parser instance
-        >>> parser.eval_array([1, 2, 3])
+        Returns MathArray instances and updates metadata_dict['max_array_dim_used']
+        if needed:
+        >>> metadata_dict = { 'max_array_dim_used': 0 }
+        >>> MathExpression.eval_array([1, 2, 3], metadata_dict)
         MathArray([1, 2, 3])
-        >>> parser.eval_array([
+        >>> metadata_dict['max_array_dim_used']
+        1
+
+        If metadata_dict['max_array_dim_used'] is larger than returned array value,
+        then metadata_dict is not updated:
+        >>> metadata_dict = { 'max_array_dim_used': 2 }
+        >>> MathExpression.eval_array([1, 2, 3], metadata_dict)
+        MathArray([1, 2, 3])
+        >>> metadata_dict['max_array_dim_used']
+        2
+
+        >>> metadata_dict = { 'max_array_dim_used': 0 }
+        >>> MathExpression.eval_array([
         ...     [1, 2],
         ...     [3, 4]
-        ... ])
+        ... ], metadata_dict)
         MathArray([[1, 2],
                [3, 4]])
 
         In practice, this is called recursively:
-        >>> parser.eval_array([
-        ...     parser.eval_array([1, 2, 3]),
-        ...     parser.eval_array([4, 5, 6])
-        ... ])
+        >>> metadata_dict = { 'max_array_dim_used': 0 }
+        >>> MathExpression.eval_array([
+        ...     MathExpression.eval_array([1, 2, 3], metadata_dict),
+        ...     MathExpression.eval_array([4, 5, 6], metadata_dict)
+        ... ], metadata_dict)
         MathArray([[1, 2, 3],
                [4, 5, 6]])
+        >>> metadata_dict['max_array_dim_used']
+        2
 
         One complex entry will convert everything to complex:
-        >>> parser.eval_array([
-        ...     parser.eval_array([1, 2j, 3]),
-        ...     parser.eval_array([4, 5, 6])
-        ... ])
+        >>> metadata_dict = { 'max_array_dim_used': 0 }
+        >>> MathExpression.eval_array([
+        ...     MathExpression.eval_array([1, 2j, 3], metadata_dict),
+        ...     MathExpression.eval_array([4, 5, 6], metadata_dict)
+        ... ], metadata_dict)
         MathArray([[ 1.+0.j,  0.+2.j,  3.+0.j],
                [ 4.+0.j,  5.+0.j,  6.+0.j]])
 
         We try to detect shape errors:
-        >>> parser.eval_array([                      # doctest: +ELLIPSIS
-        ...     parser.eval_array([1, 2, 3]),
+        >>> metadata_dict = { 'max_array_dim_used': 0 }
+        >>> MathExpression.eval_array([                      # doctest: +ELLIPSIS
+        ...     MathExpression.eval_array([1, 2, 3], metadata_dict),
         ...     4
-        ... ])
+        ... ], metadata_dict)
         Traceback (most recent call last):
         UnableToParse: Unable to parse vector/matrix. If you're trying ...
-        >>> parser.eval_array([                      # doctest: +ELLIPSIS
+        >>> metadata_dict = { 'max_array_dim_used': 0 }
+        >>> MathExpression.eval_array([                      # doctest: +ELLIPSIS
         ...     2.0,
-        ...     parser.eval_array([1, 2, 3]),
+        ...     MathExpression.eval_array([1, 2, 3], metadata_dict),
         ...     4
-        ... ])
+        ... ], metadata_dict)
         Traceback (most recent call last):
         UnableToParse: Unable to parse vector/matrix. If you're trying ...
         """
-
         shape_message = ("Unable to parse vector/matrix. If you're trying to "
                          "enter a matrix, this is most likely caused by an "
                          "unequal number of elements in each row.")
@@ -888,17 +913,16 @@ class FormulaParser(object):
             # This happens, for example, with np.array([[1], 2, 3])
             raise UnableToParse(shape_message)
 
-        if array.ndim > self.max_array_dim_used:
-            self.max_array_dim_used = array.ndim
+        if array.ndim > metadata_dict['max_array_dim_used']:
+            metadata_dict['max_array_dim_used'] = array.ndim
 
         return array
 
-    def eval_power(self, parse_result):
+    @staticmethod
+    def eval_power(parse_result):
         """
-        Take a list of numbers and exponentiate them, right to left.
-
-        Can also have minus signs interspersed, which means to flip the sign of the
-        exponent.
+        Exponentiate a list of numbers, right to left. Can also have minus signs
+        interspersed, which means to flip the sign of the exponent.
 
         Arguments:
             parse_result: A list of numbers and "-" strings, to be read as exponentiated
@@ -907,10 +931,9 @@ class FormulaParser(object):
 
         Usage
         =====
-        >>> parser = FormulaParser("1", {"%": 0.01})
-        >>> parser.eval_power([4,3,2])  # Evaluate 4^3^2
+        >>> MathExpression.eval_power([4,3,2])  # Evaluate 4^3^2
         262144
-        >>> parser.eval_power([2,"-",2,2])  # Evaluate 2^(-(2^2))
+        >>> MathExpression.eval_power([2,"-",2,2])  # Evaluate 2^(-(2^2))
         0.0625
         """
 
@@ -927,7 +950,8 @@ class FormulaParser(object):
 
         return result
 
-    def eval_negation(self, parse_result):
+    @staticmethod
+    def eval_negation(parse_result):
         """
         Negate a number an appropriate number of times.
 
@@ -938,24 +962,24 @@ class FormulaParser(object):
 
         Usage
         =====
-        >>> parser = FormulaParser("1", {"%": 0.01})
-        >>> parser.eval_negation([2])
+        >>> MathExpression.eval_negation([2])
         2
-        >>> parser.eval_negation(["-",2])
+        >>> MathExpression.eval_negation(["-",2])
         -2
-        >>> parser.eval_negation(["-","-",2])
+        >>> MathExpression.eval_negation(["-","-",2])
         2
-        >>> parser.eval_negation(["-","-","-",2])
+        >>> MathExpression.eval_negation(["-","-","-",2])
         -2
-        >>> parser.eval_negation(["-","-","-","-",2])
+        >>> MathExpression.eval_negation(["-","-","-","-",2])
         2
         """
         num = parse_result[-1]
         return num * (-1)**(len(parse_result) - 1)
 
-    def eval_parallel(self, parse_result):
+    @staticmethod
+    def eval_parallel(parse_result):
         """
-        Compute numbers according to the parallel resistors operator (note commutative).
+        Operator associated with parallel resistors (it's commutative).
 
         Return NaN if there is a zero among the inputs.
 
@@ -965,22 +989,22 @@ class FormulaParser(object):
 
         Usage
         =====
-        >>> parser = FormulaParser("1", {"%": 0.01})
-        >>> parser.eval_parallel([4,3,2])  # doctest: +ELLIPSIS
+        >>> MathExpression.eval_parallel([4,3,2])  # doctest: +ELLIPSIS
         0.9230769...
-        >>> parser.eval_parallel([1,2])  # doctest: +ELLIPSIS
+        >>> MathExpression.eval_parallel([1,2])  # doctest: +ELLIPSIS
         0.6666666...
-        >>> parser.eval_parallel([1,1])
+        >>> MathExpression.eval_parallel([1,1])
         0.5
-        >>> parser.eval_parallel([1,0])
+        >>> MathExpression.eval_parallel([1,0])
         nan
         """
         if 0 in parse_result:
-            return float('nan')
+            return float('nan') # Thinking about circuits, should x || 0 = 0 ?
         reciprocals = [1. / num for num in parse_result]
         return 1. / sum(reciprocals)
 
-    def eval_product(self, parse_result):
+    @staticmethod
+    def eval_product(parse_result):
         """
         Multiply/divide inputs appropriately
 
@@ -988,15 +1012,14 @@ class FormulaParser(object):
             parse_result: A list of numbers to combine, separated by "*" and "/"
             [a, "*", b, "/", c] = a*b/c
 
-        Has some extra logic to avoid ambiguous vector tirple products.
+        Has some extra logic to avoid ambiguous vector triple products.
         See https://github.com/mitodl/mitx-grading-library/issues/108
 
         Usage
         =====
-        >>> parser = FormulaParser("1", {"%": 0.01})
-        >>> parser.eval_product([2,"*",3,"/",4])
+        >>> MathExpression.eval_product([2,"*",3,"/",4])
         1.5
-        >>> parser.eval_product([2,"*",3,"+",4])
+        >>> MathExpression.eval_product([2,"*",3,"+",4])
         Traceback (most recent call last):
         CalcError: Unexpected symbol + in eval_product
         """
@@ -1024,12 +1047,13 @@ class FormulaParser(object):
                 raise CalcError("Unexpected symbol {} in eval_product".format(op))
 
             # Need to cast np numerics as builtins here (in addition to during
-            # handle_node) because the result is changing shape
+            # eval_node) because the result is changing shape
             result = cast_np_numeric_as_builtin(result)
 
         return result
 
-    def eval_sum(self, parse_result):
+    @staticmethod
+    def eval_sum(parse_result):
         """
         Add/subtract inputs
 
@@ -1039,12 +1063,11 @@ class FormulaParser(object):
 
         Usage
         =====
-        >>> parser = FormulaParser("1", {"%": 0.01})
-        >>> parser.eval_sum([2,"+",3,"-",4])
+        >>> MathExpression.eval_sum([2,"+",3,"-",4])
         1
-        >>> parser.eval_sum(["+",2,"+",3,"-",4])
+        >>> MathExpression.eval_sum(["+",2,"+",3,"-",4])
         1
-        >>> parser.eval_sum(["+",2,"*",3,"-",4])
+        >>> MathExpression.eval_sum(["+",2,"*",3,"-",4])
         Traceback (most recent call last):
         CalcError: Unexpected symbol * in eval_sum
         """
@@ -1062,3 +1085,93 @@ class FormulaParser(object):
             else:
                 raise CalcError("Unexpected symbol {} in eval_sum".format(op))
         return result
+
+PARSER = MathParser()
+def evaluator(formula,
+              variables=DEFAULT_VARIABLES,
+              functions=DEFAULT_FUNCTIONS,
+              suffixes=DEFAULT_SUFFIXES,
+              max_array_dim=None,
+              allow_inf=False):
+    """
+    Evaluate an expression; that is, take a string of math and return a float.
+
+    Arguments
+    =========
+    - formula (str): The formula to be evaluated
+    Pass a scope consisting of variables, functions, and suffixes:
+    - variables (dict): maps strings to variable values, defaults to DEFAULT_VARIABLES
+    - functions (dict): maps strings to functions, defaults to DEFAULT_FUNCTIONS
+    - suffixes (dict): maps strings to suffix values, defaults to DEFAULT_SUFFIXES
+    Also:
+    - max_array_dim: Maximum dimension of MathArrays
+    - allow_inf: Whether to raise an error if the evaluator encounters an infinity
+
+    NOTE: Everything is case sensitive (this is different to edX!)
+
+    Usage
+    =====
+    Evaluates the formula and records usage of functions/variables/suffixes:
+    >>> result = evaluator("1+1", {}, {}, {})
+    >>> expected = ( 2.0 , EvalMetaData(
+    ...     variables_used=set(),
+    ...     functions_used=set(),
+    ...     suffixes_used=set(),
+    ...     max_array_dim_used=0
+    ... ))
+    >>> result == expected
+    True
+    >>> result = evaluator("square(x) + 5k",
+    ...     variables={'x':5, 'y': 10},
+    ...     functions={'square': lambda x: x**2, 'cube': lambda x: x**3},
+    ...     suffixes={'%': 0.01, 'k': 1000  })
+    >>> expected = ( 5025.0 , EvalMetaData(
+    ...     variables_used=set(['x']),
+    ...     functions_used=set(['square']),
+    ...     suffixes_used=set(['k']),
+    ...     max_array_dim_used=0
+    ... ))
+    >>> result == expected
+    True
+
+    Empty submissions evaluate to nan:
+    >>> evaluator("")[0]
+    nan
+
+    Submissions that generate infinities will raise an error:
+    >>> evaluator("inf", variables={'inf': float('inf')})[0]  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    CalcOverflowError: Numerical overflow occurred. Does your expression generate ...
+
+    Unless you specify that infinity is ok:
+    >>> evaluator("inf", variables={'inf': float('inf')}, allow_inf=True)[0]
+    inf
+    """
+
+    empty_usage = EvalMetaData(variables_used=set(),
+                               functions_used=set(),
+                               suffixes_used=set(),
+                               max_array_dim_used=0)
+    if formula is None:
+        # No need to go further.
+        return float('nan'), empty_usage
+    formula = formula.strip()
+    if formula == "":
+        # No need to go further.
+        return float('nan'), empty_usage
+
+    parsed = PARSER.parse(formula)
+    result, eval_metadata = parsed.eval(variables, functions, suffixes, allow_inf=allow_inf)
+
+    # Were vectors/matrices/tensors used when they shouldn't have been?
+    if max_array_dim is not None and eval_metadata.max_array_dim_used > max_array_dim:
+        if max_array_dim == 0:
+            msg = "Vector and matrix expressions have been forbidden in this entry."
+        elif max_array_dim == 1:
+            msg = "Matrix expressions have been forbidden in this entry."
+        else:
+            msg = "Tensor expressions have been forbidden in this entry."
+        raise UnableToParse(msg)
+
+    # Return the result of the evaluation, as well as the set of functions used
+    return result, eval_metadata

--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -1,5 +1,5 @@
 """
-calc.py
+expressions.py
 
 Defines classes to parse and evaluate mathematical expressions.
 
@@ -27,11 +27,18 @@ in two steps:
     2. Next, the tree is evaluated from the leaves upwards.
 
 This file defines two main classes:
+
  - MathParser, used to parse mathematical strings into a tree
  - MathExpression, holds the parse tree for a given mathematical expression
    and can be used to evaluate the tree with a given scope.
 and a function:
+
+and also:
+ - PARSER: global MathParser instance that should be used throughout mitxgraders
  - evaluator: a convenience function that parses and evaluates strings.
+
+
+
 """
 from __future__ import division
 import copy
@@ -321,13 +328,13 @@ class MathParser(object):
 
     def function_parse_action(self, tokens):
         """
-        When pyparsing encounters a function, store it in variables_used
+        When pyparsing encounters a function, store it in functions_used
         """
         self.functions_used.add(tokens[0][0])
 
     def suffix_parse_action(self, tokens):
         """
-        When pyparsing encounters a suffix, store it in variables_used
+        When pyparsing encounters a suffix, store it in suffixes_used
         """
         self.suffixes_used.add(tokens[0])
 

--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -1,7 +1,9 @@
 """
 expressions.py
 
-Defines classes to parse and evaluate mathematical expressions.
+Defines classes to parse and evaluate mathematical expressions. Implements
+similar functionality and API as edX's calc.py, but re-written with enhancements
+and to betterseparate parsing and evaluation.
 
 To evaluate a mathematical expression like '2^a + [x, 2]*[y, 4]', we proceed
 in two steps:

--- a/mitxgraders/helpers/calc/robust_pow.py
+++ b/mitxgraders/helpers/calc/robust_pow.py
@@ -3,7 +3,7 @@ import numpy as np
 Contains the power function used by MathArray and parsing.py
 """
 
-# This is used in calc.py's eval_power function also.
+# This is used in expressions.py's eval_power function also.
 def robust_pow(base, exponent):
     """
     Calculates __pow__, and tries other approachs if that doesn't work.

--- a/mitxgraders/plugins/integralgrader.py
+++ b/mitxgraders/plugins/integralgrader.py
@@ -485,7 +485,7 @@ class IntegralGrader(AbstractGrader):
                                       suffixes={},
                                       allow_inf=True)
 
-        used_funcs = lower_used.functions.union(upper_used.functions).union(integrand_used.functions)
+        used_funcs = lower_used.functions_used.union(upper_used.functions_used, integrand_used.functions_used)
 
         return lower, upper, used_funcs
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest==3.6.2
-pytest-cov
+pytest-cov==2.5.1
 pylint
 mock
 mkdocs==0.17.5

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -94,11 +94,11 @@ def test_fg_invalid_input():
     with raises(CalcError, match=expect):
         grader(None, "R")
 
-    expect = "Invalid Input: pp not permitted directly after a number."
+    expect = "Invalid Input: pp not permitted directly after a number"
     with raises(CalcError, match=expect):
         grader(None, "5pp")
 
-    expect = "Invalid Input: m not permitted directly after a number. \(did you forget to use \* for multiplication\?\)"
+    expect = "Invalid Input: m not permitted directly after a number \(did you forget to use \* for multiplication\?\)"
     with raises(CalcError, match=expect):
         grader(None, "5m")
 
@@ -169,7 +169,7 @@ def test_fg_percent():
     )
     assert grader(None, "2%")['ok']
     assert grader(None, "0.02")['ok']
-    with raises(CalcError, match="Invalid Input: m not permitted directly after a number."):
+    with raises(CalcError, match="Invalid Input: m not permitted directly after a number"):
         grader(None, "20m")
 
 def test_fg_metric():

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -74,7 +74,7 @@ def test_fg_expressions():
     assert not grader(None, "0.02+(cos(3/2) + sin(3/2))/cos(3/2 + 2*pi)")['ok']
 
 def test_fg_invalid_input():
-    grader = FormulaGrader(answers='2')
+    grader = FormulaGrader(answers='2', variables=['m'])
 
     expect = 'Invalid Input: pi not permitted in answer as a function ' + \
              '\(did you forget to use \* for multiplication\?\)'
@@ -94,9 +94,13 @@ def test_fg_invalid_input():
     with raises(CalcError, match=expect):
         grader(None, "R")
 
-    expect = "Invalid Input: Could not parse '5pp' as a formula"
+    expect = "Invalid Input: pp not permitted directly after a number."
     with raises(CalcError, match=expect):
         grader(None, "5pp")
+
+    expect = "Invalid Input: m not permitted directly after a number. \(did you forget to use \* for multiplication?"
+    with raises(CalcError, match=expect):
+        grader(None, "5m")
 
     expect = ("There was an error evaluating csc\(...\). "
               "Its input does not seem to be in its domain.")
@@ -165,7 +169,7 @@ def test_fg_percent():
     )
     assert grader(None, "2%")['ok']
     assert grader(None, "0.02")['ok']
-    with raises(CalcError, match="Invalid Input: Could not parse '20m' as a formula"):
+    with raises(CalcError, match="Invalid Input: m not permitted directly after a number."):
         grader(None, "20m")
 
 def test_fg_metric():

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -98,7 +98,7 @@ def test_fg_invalid_input():
     with raises(CalcError, match=expect):
         grader(None, "5pp")
 
-    expect = "Invalid Input: m not permitted directly after a number. \(did you forget to use \* for multiplication?"
+    expect = "Invalid Input: m not permitted directly after a number. \(did you forget to use \* for multiplication\?\)"
     with raises(CalcError, match=expect):
         grader(None, "5m")
 

--- a/tests/helpers/calc/test_expressions.py
+++ b/tests/helpers/calc/test_expressions.py
@@ -1,5 +1,5 @@
 """
-Tests of calc.py
+Tests of expression.py that arent covered elsewhere
 """
 from __future__ import division
 import re
@@ -28,16 +28,22 @@ def test_calcpy():
     # Test formula with None
     value, used = evaluator(None, {}, {}, {})
     assert value == approx(float('nan'), nan_ok=True)
-    assert (used.functions, used.variables, used.suffixes) == (set(), set(), set())
+    assert used.functions_used == set()
+    assert used.variables_used == set()
+    assert used.suffixes_used == set()
 
     # Test formulae with parallel operator
     value, used = evaluator("1 || 1 || 1", {}, {}, {})
     assert value == 1/3
-    assert (used.functions, used.variables, used.suffixes) == (set(), set(), set())
+    assert used.functions_used == set()
+    assert used.variables_used == set()
+    assert used.suffixes_used == set()
 
     value, used = evaluator("1 || 1 || 0", {}, {}, {})
     assert value == approx(float('nan'), nan_ok=True)
-    assert (used.functions, used.variables, used.suffixes) == (set(), set(), set())
+    assert used.functions_used == set()
+    assert used.variables_used == set()
+    assert used.suffixes_used == set()
 
     # Test incorrect case variables
     msg = r"Invalid Input: X not permitted in answer as a variable \(did you mean x\?\)"
@@ -128,7 +134,6 @@ def test_calc_functions_multiple_arguments():
     with raises(ArgumentError):
         evaluator("h(1,2)", {}, {"h": h3}, {})
 
-
 def test_negation():
     """Test that appropriate numbers of +/- signs are accepted"""
     assert evaluator("1+-1")[0] == 0
@@ -189,3 +194,11 @@ def test_div_by_zero():
         evaluator("1/0")
     with raises(CalcZeroDivisionError, match=msg):
         evaluator("0^-1")
+
+def test_suffix_capitalization_error():
+    variables = {}
+    functions = {}
+    suffixes = {'M'}
+    match = "Invalid Input: m not permitted directly after a number. \(did you mean M\?\)"
+    with raises(CalcError, match=match):
+        evaluator('5m', variables, functions, suffixes)

--- a/tests/helpers/calc/test_expressions.py
+++ b/tests/helpers/calc/test_expressions.py
@@ -1,5 +1,5 @@
 """
-Tests of expression.py that arent covered elsewhere
+Tests of expressions.py that aren't covered elsewhere
 """
 from __future__ import division
 import re
@@ -14,8 +14,8 @@ from mitxgraders.helpers.calc.exceptions import (
 )
 from mitxgraders.helpers.calc.math_array import equal_as_arrays, MathArray
 
-def test_calcpy():
-    """Tests of calc.py that aren't covered elsewhere"""
+def test_expressions_py():
+    """Tests of expressions.py that aren't covered elsewhere"""
 
     # Test unhandled exception
     def badfunc(a):
@@ -51,7 +51,7 @@ def test_calcpy():
         evaluator("X", {"x": 1}, {}, {})
 
 def test_varnames():
-    """Test variable names in calc.py"""
+    """Test parsing of variable names"""
     # Tensor variable names
     assert evaluator("U^{ijk}", {"U^{ijk}": 2}, {}, {})[0] == 2
     assert evaluator("U_{ijk}/2", {"U_{ijk}": 2}, {}, {})[0] == 1
@@ -107,7 +107,7 @@ def test_brackets_closed_by_wrong_type_raise_error():
         evaluator("5 + (1+2] + 3")
 
 def test_calc_functions_multiple_arguments():
-    """Tests calc.py handling functions with multiple arguments correctly"""
+    """Tests parse/eval handling functions with multiple arguments correctly"""
     def h1(x): return x
 
     def h2(x, y): return x * y

--- a/tests/helpers/calc/test_expressions.py
+++ b/tests/helpers/calc/test_expressions.py
@@ -39,12 +39,6 @@ def test_expressions_py():
     assert used.variables_used == set()
     assert used.suffixes_used == set()
 
-    value, used = evaluator("1 || 1 || 0", {}, {}, {})
-    assert value == approx(float('nan'), nan_ok=True)
-    assert used.functions_used == set()
-    assert used.variables_used == set()
-    assert used.suffixes_used == set()
-
     # Test incorrect case variables
     msg = r"Invalid Input: X not permitted in answer as a variable \(did you mean x\?\)"
     with raises(UndefinedVariable, match=msg):

--- a/tests/helpers/calc/test_expressions.py
+++ b/tests/helpers/calc/test_expressions.py
@@ -199,6 +199,6 @@ def test_suffix_capitalization_error():
     variables = {}
     functions = {}
     suffixes = {'M'}
-    match = "Invalid Input: m not permitted directly after a number. \(did you mean M\?\)"
+    match = "Invalid Input: m not permitted directly after a number \(did you mean M\?\)"
     with raises(CalcError, match=match):
         evaluator('5m', variables, functions, suffixes)

--- a/tests/helpers/calc/test_expressions_arrays.py
+++ b/tests/helpers/calc/test_expressions_arrays.py
@@ -1,3 +1,6 @@
+"""
+tests of expression.py with arrays
+"""
 from __future__ import division
 from pytest import raises
 import numpy as np

--- a/tests/helpers/calc/test_expressions_arrays.py
+++ b/tests/helpers/calc/test_expressions_arrays.py
@@ -9,7 +9,7 @@ from mitxgraders.helpers.calc.math_array import equal_as_arrays
 from mitxgraders.helpers.calc.exceptions import UnableToParse, CalcError
 
 def test_array_input():
-    """Test that vectors/matrices can be inputted into calc.py"""
+    """Test that vectors/matrices can be inputted into calc's evaluator"""
     result = evaluator("[1, 2, 3]", {}, {}, {}, max_array_dim=1)[0]
     assert equal_as_arrays(result, MathArray([1, 2, 3]))
 


### PR DESCRIPTION
Rewrote much of `calc.py` and changed name to `expressions.py`

Noteable changes:

1. I tried to separate parsing and evaluation as much as possible. Usage now looks like:

    ```python
    parser = MathParser()
    expr_1 = parser.parse('x + y')
    expr_2 = parser.parse('x*y')
    
    variables_A = { 'x': 5, 'y': 7 }
    variables_B = {'x': -3, 'y': 4}
    
    expr_1.eval(variables_A, {}, {}, {})
    expr_1.eval(variables_B, {}, {}, {}) # evaluate the same expression with different variables, do not re-parse
    
    expr_2.eval(variables_A, {}, {}, {})
    expr_2.eval(variables_B, {}, {}, {}) # evaluate the same expression with different variables, do not re-parse
    ```
2. I changed the grammar so that the **parser** accepts all alphabetic suffixes and '%'. Advantages:
    - Allows us to give better error messages for things like `'x + 5y'`. We used to just say "Unable to parse". Now the expression DOES parse, but we can say "y not allowed directly after number, did you forget `*`?"
    - Resolves the weirdness in #132
