### PR TITLE
Adding JS definition for arctan2

### DIFF
--- a/MJxPrep.js
+++ b/MJxPrep.js
@@ -101,6 +101,14 @@ if (window.MJxPrep) {
       // See https://github.com/asciimath/asciimathml/blob/master/ASCIIMathML.js
       // Add functions, including some edX functions that don't exist in AsciiMath
       AM.newsymbol({
+        input: "arctan2",
+        tag: "mi",
+        output: "arctan",
+        tex: null,
+        ttype: AM.TOKEN.UNARY,
+        func: true
+      });
+      AM.newsymbol({
         input: "arcsec",
         tag: "mi",
         output: "arcsec",


### PR DESCRIPTION
Just making sure that our new function renders properly :-) I chose to go with `arctan(x, y)` as the render.