### PR TITLE
Infer expect

### DIFF
--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -92,26 +92,28 @@ class AbstractGrader(ObjectWithSchema):
         Used by edX as the check function (cfn).
 
         Arguments:
-            expect: The value of edX customresponse expect attribute (ignored)
+            expect: The value of edX customresponse expect attribute (ignored).
             student_input: The student's input passed by edX
 
         Notes:
-            This function ignores the value of expect.
+            This function ignores the value of expect. The expect argument is
+            provided because edX requires that a check function to have the
+            signature above.
 
-            The expect argument is provided because edX expects a check function
-            to have the signature above. Our graders usually ignore the first
-            argument, expect. Instead, we usually pass None as the expect value,
-            indicating that the grader should instead read the expected answer
-            from the grader's configuration. This is because we generally use
+            Our graders usually read the author's expected answer from the
+            grader configuration. This is because we generally use
             dictionaries to store the expected input along with correctness,
             grades, and feedback messages.
 
-            Note that authors should still specify the <customresponse />
+            Authors should still specify the <customresponse />
             expect attribute because its value is displayed to students as
             the "correct" answer.
 
-            Note: ItemGraders can infer its answers from the their answers from
-            the expect value of a customresponse tag.
+            ItemGraders: If no answer is provided in the configuration, an
+            ItemGrader will attempt to infer its answer from the expect
+            parameter of a textline or CustomResponse tag. Note that this does
+            not work when an ItemGrader is embedded inside a ListGrader. See
+            ItemGrader.__call__ the implementation.
         """
         # Initialize the debug log
         # The debug log always exists and is written to, so that it can be accessed

--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -414,3 +414,14 @@ class ItemGrader(AbstractGrader):
             **kwargs: Anything else that has been passed in. For example, sibling
                 graders when a grader is used as a subgrader in a ListGrader.
         """
+
+    def __call__(self, expect, student_input):
+        """
+        The same as AbstractGrader.__call__, except that we try to infer
+        answers from expect argument if answers are not specified in the
+        grader configuration.
+        """
+        if not self.config['answers'] and expect is not None:
+            self.config['answers'] = self.schema_answers(expect)
+
+        return super(ItemGrader, self).__call__(expect, student_input)

--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -113,7 +113,7 @@ class AbstractGrader(ObjectWithSchema):
             ItemGrader will attempt to infer its answer from the expect
             parameter of a textline or CustomResponse tag. Note that this does
             not work when an ItemGrader is embedded inside a ListGrader. See
-            ItemGrader.__call__ the implementation.
+            ItemGrader.__call__ for the implementation.
         """
         # Initialize the debug log
         # The debug log always exists and is written to, so that it can be accessed

--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -98,19 +98,20 @@ class AbstractGrader(ObjectWithSchema):
         Notes:
             This function ignores the value of expect.
 
-            This is because edX requires a two-parameter check function cfn
-            with the signature above. In the graders module, we NEVER use
-            the <customresponse /> tag's expect attribute for grading.
+            The expect argument is provided because edX expects a check function
+            to have the signature above. Our graders usually ignore the first
+            argument, expect. Instead, we usually pass None as the expect value,
+            indicating that the grader should instead read the expected answer
+            from the grader's configuration. This is because we generally use
+            dictionaries to store the expected input along with correctness,
+            grades, and feedback messages.
 
-            (Our check functions require an answer dictionary, as described
-            in the documentation.)
-
-            But we do want to allow authors to use the edX <customresponse />
+            Note that authors should still specify the <customresponse />
             expect attribute because its value is displayed to students as
             the "correct" answer.
 
-            The answer that we pass to check is None, indicating that the
-            grader should read the answer from its internal configuration.
+            Note: ItemGraders can infer its answers from the their answers from
+            the expect value of a customresponse tag.
         """
         # Initialize the debug log
         # The debug log always exists and is written to, so that it can be accessed

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -121,6 +121,14 @@ def test_itemgrader():
     assert grader(None, "2")['ok']
     assert not grader(None, "3")['ok']
 
+def test_itemgrader_infers_answers_from_expect():
+    grader = StringGrader()
+    expect = 'cat'
+    student_input_1 = 'cat'
+    student_input_2 = 'dog'
+    assert grader(expect, student_input_1)['ok']
+    assert not grader(expect, student_input_2)['ok']
+
 def test_single_expect_value_in_config():
     grader = StringGrader(
         answers='cat'


### PR DESCRIPTION
This addresses #150 for ItemGraders only. Implementing this for ItemGrader only was very easy because ItemGraders have a strictly specified answers schema.

I suspect we could do something that works in general, but I would need to think a bit more about it.

I wrote this fairly quickly in case you wanted it for today's workshop. I think it should be safe to merge, but feel free to reject if you want a more general solution =).