### PR TITLE
Fixing Unicode

### DIFF
--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -425,6 +425,6 @@ class ItemGrader(AbstractGrader):
         grader configuration.
         """
         if not self.config['answers'] and expect is not None:
-            self.config['answers'] = self.schema_answers(expect)
+            self.config['answers'] = self.schema_answers(expect.encode('utf-8'))
 
         return super(ItemGrader, self).__call__(expect, student_input)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -123,7 +123,7 @@ def test_itemgrader():
 
 def test_itemgrader_infers_answers_from_expect():
     grader = StringGrader()
-    expect = 'cat'
+    expect = u'cat'
     student_input_1 = 'cat'
     student_input_2 = 'dog'
     assert grader(expect, student_input_1)['ok']


### PR DESCRIPTION
So, it turns out that edX sends us a unicode version of the expect string, not a string version. This fixes the appropriate pieces and makes everything work on edX :-)