### PR TITLE
Clarifying equality checks when objects may be arrays

### DIFF
--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -979,7 +979,7 @@ class MathExpression(object):
         while data:
             # Result contains the current exponent
             working = data.pop()
-            if working == "-":
+            if isinstance(working, str) and working == "-":
                 result = -result
             else:
                 # working is base, result is exponent
@@ -1110,7 +1110,7 @@ class MathExpression(object):
         """
         data = parse_result[:]
         result = data.pop(0)
-        if result == "+":
+        if isinstance(result, str) and result == "+":
             result = data.pop(0)
         while data:
             op = data.pop(0)


### PR DESCRIPTION
There are some equality checks in `expressions.py` against strings. These equality checks give rise to warnings when the object being checked against is an array. We need to check if they're strings before doing such a comparison. Note that I'm not sure I caught all of them here.

Here is a minimal working example to see the problem (before this PR):
```python
from mitxgraders import *
grader = MatrixGrader(
    variables=['A'],
    sample_from={'A': RealMatrices()}
)
print(grader('(A-2*A)^2', '(A-2*A)^2'))
```

I'm also not sure how to test this...