### PR TITLE
Introducing flag to suppress matrix error messages

### DIFF
--- a/course/course/course.xml
+++ b/course/course/course.xml
@@ -41,6 +41,7 @@
         <problem url_name="matrix5"/>
         <problem url_name="matrix6"/>
         <problem url_name="matrix7"/>
+        <problem url_name="matrix8"/>
         <problem url_name="matrixtech"/>
       </vertical>
     </sequential>

--- a/course/problem/matrix8.xml
+++ b/course/problem/matrix8.xml
@@ -1,0 +1,44 @@
+<problem display_name="Matrix Grader: Noncommuting Variables" showanswer="always" weight="10" attempts="">
+
+<p>Sometimes, you want to work with non-commuting variables or operations. These can be straightforwardly implemented as matrices, as in the following example. Note that although we secretly have matrix variables, students do not need to know this, and hence we never give error messages that have anything to do with matrices.</p>
+
+<p>[mathjaxinline]A[/mathjaxinline] is a scalar function. Write down its gradient.</p>
+
+<p>Suggested inputs:</p>
+
+<ul>
+  <li><code>nabla * A</code> (correct)</li>
+  <li><code>A * nabla</code> (incorrect)</li>
+  <li><code>nabla * A + 1</code> (incorrect, but looks like a matrix + a scalar)</li>
+</ul>
+
+<script type="text/python" system_path="python_lib">
+from mitxgraders import *
+grader = MatrixGrader(
+    variables=['nabla', 'A'],
+    sample_from={
+        'nabla': RealMatrices(),
+        'A': RealMatrices()
+    },
+    max_array_dim=0,               # Students can't enter their own matrices
+    suppress_matrix_messages=True  # Turns off all matrix error messages
+)
+</script>
+
+<p style="display:inline">Gradient of \(A\) = </p>
+<customresponse cfn="grader" expect="nabla * A" inline="1">
+  <textline math="true" preprocessorClassName="MJxPrep" preprocessorSrc="/static/MJxPrep.js" size="40" inline="1" />
+</customresponse>
+
+
+<h3>Resources</h3>
+<ul>
+  <li>
+    <a href="https://github.com/mitodl/mitx-grading-library/tree/master/course/problem/matrix7.xml" target="_blank">View source</a>
+  </li>
+  <li>
+    <a href="https://mitodl.github.io/mitx-grading-library/grading_math/comparer_functions/" target="_blank">Documentation for <code>comparer_functions</code></a>
+  </li>
+</ul>
+
+</problem>

--- a/docs/grading_math/matrix_grader/matrix_grader.md
+++ b/docs/grading_math/matrix_grader/matrix_grader.md
@@ -313,6 +313,26 @@ we can use:
 
 ```
 
+### Hiding all messages
+
+MatrixGraders can be used to introduce non-commuting variables. In such a situation, students may not know that the variables they are using are matrices "under the hood", and so we want to suppress all matrix errors and messages. We can do this by setting `suppress_matrix_messages=True`, which overrides `answer_shape_mismatch={'is_raised'}` and `shape_errors`. In the following example, `A` and `B` are secretly matrices that don't commute, but students will never see a matrix error message from typing something like `1+A`.
+
+```
+grader = MatrixGrader(
+    answers=['A*B'],
+    variables=['A', 'B'],
+    sample_from={
+        'A': RealMatrices(),
+        'B': RealMatrices()
+    },
+    max_array_dim=0,
+    suppress_matrix_messages=True
+)
+```
+
+Note that this will also suppress error messages from trying to do things like `sin([1, 2])` or `[1, 2]^2`. If your answer needs to take functions of the non-commuting variables, then this option is insufficient.
+
+
 ## Matrix Functions
 
 MatrixGrader provides all the default functions of `FormulaGrader` (`sin`, `cos`, etc.) plus some extras such as `trans(A)` (transpose) and `det(A)` (determinant). See [Mathematical Functions]('../functions_and_constants.md') for full list.

--- a/mitxgraders/formulagrader/matrixgrader.py
+++ b/mitxgraders/formulagrader/matrixgrader.py
@@ -11,7 +11,7 @@ from mitxgraders.formulagrader.formulagrader import FormulaGrader
 from mitxgraders.helpers.validatorfuncs import NonNegative
 from mitxgraders.helpers.calc import MathArray, within_tolerance, identity
 from mitxgraders.helpers.calc.exceptions import (
-    MathArrayShapeError as ShapeError, MathArrayError, DomainError)
+    MathArrayShapeError as ShapeError, MathArrayError, DomainError, ArgumentShapeError)
 from mitxgraders.helpers.calc.mathfuncs import (
     merge_dicts, ARRAY_ONLY_FUNCTIONS)
 
@@ -105,10 +105,10 @@ class MatrixGrader(FormulaGrader):
                 raise
             else:
                 return {'ok': False, 'grade_decimal': 0, 'msg': err.message}
-        except (DomainError, MathArrayError) as err:
+        except (ArgumentShapeError, MathArrayError) as err:
             # If we're using matrix quantities for noncommutative scalars, we
-            # might get a DomainError from using functions of matrices, or
-            # a MathArrayError from taking a funny power of a matrix.
+            # might get an ArgumentShapeError from using functions of matrices,
+            # or a MathArrayError from taking a funny power of a matrix.
             # Suppress these too.
             if self.config['suppress_matrix_messages']:
                 return {'ok': False, 'msg': '', 'grade_decimal': 0}

--- a/mitxgraders/helpers/calc/exceptions.py
+++ b/mitxgraders/helpers/calc/exceptions.py
@@ -54,6 +54,12 @@ class ArgumentError(DomainError):
     """
     pass
 
+class ArgumentShapeError(DomainError):
+    """
+    Raised when the wrong type of argument is passed to a function
+    """
+    pass
+
 class MathArrayError(CalcError):
     """
     Thrown by MathArray when anticipated errors are made.

--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -800,7 +800,7 @@ class MathExpression(object):
         >>> def h(x, y): return x + y
         >>> MathExpression.eval_function(['h', [1, 2, 3]], {"h": h})
         Traceback (most recent call last):
-        ArgumentError: Wrong number of arguments passed to h. Expected 2, received 3.
+        ArgumentError: Wrong number of arguments passed to h(...): Expected 2 inputs, but received 3.
 
         However, if the function to be evaluated has a truthy 'validated'
         property, we assume it does its own validation and we do not check the
@@ -854,8 +854,8 @@ class MathExpression(object):
         num_args = len(args)
         expected = get_number_of_args(func)
         if expected != num_args:
-            msg = ("Wrong number of arguments passed to {func}. "
-                   "Expected {num}, received {num2}.")
+            msg = ("Wrong number of arguments passed to {func}(...): "
+                   "Expected {num} inputs, but received {num2}.")
             raise ArgumentError(msg.format(func=name, num=expected, num2=num_args))
         return True
 

--- a/mitxgraders/helpers/validatorfuncs.py
+++ b/mitxgraders/helpers/validatorfuncs.py
@@ -30,7 +30,7 @@ def PercentageString(value):
                 return "{percent}%".format(percent=percent)
             except Invalid:
                 raise
-            except:
+            except Exception:
                 pass
 
     raise Invalid("Not a valid percentage string")

--- a/tests/formulagrader/test_matrixgrader.py
+++ b/tests/formulagrader/test_matrixgrader.py
@@ -3,7 +3,7 @@ import re
 from mitxgraders import (MatrixGrader, RealMatrices, RealVectors, ComplexRectangle)
 from mitxgraders.formulagrader.matrixgrader import InputTypeError
 from mitxgraders.helpers.calc.exceptions import (
-    DomainError, MathArrayError,
+    DomainError, MathArrayError, ArgumentError,
     MathArrayShapeError as ShapeError, UnableToParse
 )
 from mitxgraders.helpers.calc.math_array import identity, equal_as_arrays
@@ -258,3 +258,7 @@ def test_suppress_matrix_messages():
     assert grader(None, '[1, 2, 3, 4]')['msg'] == ''
     assert grader(None, 'sin([1, 2, 3])')['ok'] is False
     assert grader(None, '[1, 2, 3]^1.3')['ok'] is False
+
+    # Note that we haven't suppressed all errors:
+    with raises(ArgumentError):
+        grader(None, 'sin(1, 2)')

--- a/tests/formulagrader/test_matrixgrader.py
+++ b/tests/formulagrader/test_matrixgrader.py
@@ -240,3 +240,21 @@ def test_wrong_answer_type_error_messages_with_scalars():
 def test_validate_student_input_shape_edge_case():
     with raises(AttributeError):
         MatrixGrader.validate_student_input_shape([1, 2], (2,), 'type')
+
+def test_suppress_matrix_messages():
+    grader = MatrixGrader(
+        answers='[1, 2, 3]',
+        answer_shape_mismatch=dict(
+            is_raised=True,  # Overridden by suppress_matrix_messages
+        ),
+        shape_errors=True,  # Overridden by suppress_matrix_messages
+        suppress_matrix_messages=True
+    )
+    assert grader(None, '10')['ok'] is False
+    assert grader(None, '10')['msg'] == ''
+    assert grader(None, '[1, 2, 3] + 1')['ok'] is False
+    assert grader(None, '[1, 2, 3] + 1')['msg'] == ''
+    assert grader(None, '[1, 2, 3, 4]')['ok'] is False
+    assert grader(None, '[1, 2, 3, 4]')['msg'] == ''
+    assert grader(None, 'sin([1, 2, 3])')['ok'] is False
+    assert grader(None, '[1, 2, 3]^1.3')['ok'] is False

--- a/tests/helpers/calc/test_specify_domain.py
+++ b/tests/helpers/calc/test_specify_domain.py
@@ -85,7 +85,7 @@ def test_incorrect_arguments_raise_errors():
 
 def test_incorrect_number_of_inputs_raises_useful_error():
     f = get_somefunc()
-    match = 'There was an error evaluating function somefunc\(...\): expected 4 inputs, but received 2.'
+    match = 'Wrong number of arguments passed to somefunc\(...\): Expected 4 inputs, but received 2.'
     with raises(DomainError, match=match):
         f(1, 2)
 


### PR DESCRIPTION
This PR introduces a flag to `MatrixGrader` that completely suppresses all matrix error messages. This is useful when variables are secretly being used as matrices due to their noncommutativity, but matrix error messages would be confusing to students. Includes code, tests, documentation and course example.