### PR TITLE
Fixing whitespace parsing

### DIFF
--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -528,7 +528,7 @@ class MathParser(object):
             return self.cache[cache_key]
 
         try:
-            parsed = self.raw_parse(expression)
+            parsed = self.raw_parse(expression_no_whitespace)
         except ParseException:
             msg = "Invalid Input: Could not parse '{}' as a formula"
             raise UnableToParse(msg.format(expression))

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -885,3 +885,11 @@ def test_numbered_vars():
     assert grader(None, 'a_{0}+a_{1}+a_{-1}')['ok']
     with raises(UndefinedVariable, match="a not permitted in answer as a variable"):
         grader(None, 'a')
+
+def test_whitespace_stripping():
+    """Test that formulas work regardless of whitespace"""
+    grader = FormulaGrader(
+        variables=['x_{ab}'],
+        answers='x _ { a b }'
+    )
+    assert grader(None, 'x_{a b}')['ok']

--- a/tests/helpers/calc/test_expressions.py
+++ b/tests/helpers/calc/test_expressions.py
@@ -68,14 +68,14 @@ def test_bracket_balancing_open_without_close_raises_error():
     # parens only
     match = ("Invalid Input:\n"
              "2 parentheses were opened without being closed (highlighted below)\n"
-             "<code>5 + <mark>(</mark>(1) + <mark>(</mark></code>")
+             "<code>5+<mark>(</mark>(1)+<mark>(</mark></code>")
     with raises(UnbalancedBrackets, match=re.escape(match)):
         evaluator("5 + ((1) + (")
 
     # brackets only
     match = ("Invalid Input:\n"
              "1 square bracket was opened without being closed (highlighted below)\n"
-             "<code>5 + <mark>[</mark>1, (1 + 2),</code>")
+             "<code>5+<mark>[</mark>1,(1+2),</code>")
     with raises(UnbalancedBrackets, match=re.escape(match)):
         evaluator("5 + [1, (1 + 2), ")
 
@@ -83,21 +83,21 @@ def test_bracket_balancing_open_without_close_raises_error():
     match = ("Invalid Input:\n"
              "1 parenthesis was opened without being closed (highlighted below)\n"
              "1 square bracket was opened without being closed (highlighted below)\n"
-             "<code>5 + <mark>(</mark>(1) + <mark>[</mark></code>")
+             "<code>5+<mark>(</mark>(1)+<mark>[</mark></code>")
     with raises(UnbalancedBrackets, match=re.escape(match)):
         evaluator("5 + ((1) + [")
 
 def test_brackets_close_without_open_raises_error():
     match = ("Invalid Input: a parenthesis was closed without ever being "
              "opened, highlighted below.\n"
-             "<code>5 + <mark>)</mark>1) + 1</code>")
+             "<code>5+<mark>)</mark>1)+1</code>")
     with raises(UnbalancedBrackets, match=re.escape(match)):
         evaluator("5 + )1) + 1")
 
 def test_brackets_closed_by_wrong_type_raise_error():
     match = ("Invalid Input: a parenthesis was opened and then closed by a "
              "square bracket, highlighted below.\n"
-             "<code>5 + <mark>(</mark>1+2<mark>]</mark> + 3</code>")
+             "<code>5+<mark>(</mark>1+2<mark>]</mark>+3</code>")
     with raises(UnbalancedBrackets, match=re.escape(match)):
         evaluator("5 + (1+2] + 3")
 


### PR DESCRIPTION
There's a bug in the parser due to the fact that parsing isn't actually stripping out whitespaces. Here's a simple example that trips things up:

```python
from mitxgraders import *
grader = FormulaGrader(variables=['x_{ab}'])
pp(grader('x_{a b}', 'x_{a b}'))
```

(Note that variables cannot have a space in the name.)

This PR fixes the issue.