### PR TITLE
Adding IdentityMatrixMultiples sampler

### DIFF
--- a/docs/grading_math/sampling.md
+++ b/docs/grading_math/sampling.md
@@ -98,7 +98,7 @@ If you want to sample a matrix in a way that depends on a scalar, see `Dependent
 
 ### IdentityMatrixMultiples
 
-Sample square matrices of a given dimension consisting of the identity matrix multiplied by a scalar. The `sampler` parameter can be any scalar sampling set listed above, as well as `DiscreteSet` (see below). This sampling set is useful when you want a variable that will commute with other matrices, but can also be added to them.
+Sample square matrices of a given dimension consisting of the identity matrix multiplied by a scalar. The `sampler` parameter can be any scalar sampling set listed above. This sampling set is useful when you want a variable that will commute with other matrices, but can also be added to them.
 
 ```python
 >>> # Sample 3x3 matrices consisting of a random number between 1 and 3 multiplying the identity
@@ -113,7 +113,7 @@ Sample square matrices of a given dimension consisting of the identity matrix mu
 
 ### DiscreteSet
 
-Sample from a discrete set of scalar values, specified in a tuple. A single value may also be provided, but this case should usually be specified as a constant instead of as a sampling set.
+Sample from any discrete set of values that are specified in a tuple. A single value may also be provided, but this case should usually be specified as a constant instead of as a sampling set.
 
 ```python
 >>> # Select random numbers from (1, 3, 5, 7, 9)
@@ -124,7 +124,6 @@ Sample from a discrete set of scalar values, specified in a tuple. A single valu
 >>> sampler = (1, 3, 5, 7, 9)
 
 ```
-
 
 ### DependentSampler
 

--- a/docs/grading_math/sampling.md
+++ b/docs/grading_math/sampling.md
@@ -4,7 +4,7 @@ Whenever random variables/functions are involved, they need to be sampled from a
 
 These sampling classes are available for use in `FormulaGrader`, `MatrixGrader`, etc.
 
-## Variable Sampling: Numbers
+## Variable Sampling: Numbers (Scalars)
 
 These sampling sets generate a random number on demand. It may be real or complex.
 
@@ -87,7 +87,7 @@ Sample real vectors with specified shape (number of components) and norm.
 Sample real matrices of a specific shape and norm. (`RealMatrices` uses the Frobenius norm.)
 
 ```python
->>> # Sample 3 b 2 real matrices with norm between 5 and 10
+>>> # Sample 3 by 2 real matrices with norm between 5 and 10
 >>> sampler = RealMatrices(shape=[3, 2], norm=[5, 10])
 >>> # the default is shape=[2, 2] and norm=[1, 5]
 >>> RealMatrices()
@@ -96,12 +96,24 @@ Sample real matrices of a specific shape and norm. (`RealMatrices` uses the Frob
 
 If you want to sample a matrix in a way that depends on a scalar, see `DependentSampler` below.
 
+### IdentityMatrixMultiples
+
+Sample square matrices of a given dimension consisting of the identity matrix multiplied by a scalar. The `sampler` parameter can be any scalar sampling set listed above, as well as `DiscreteSet` (see below). This sampling set is useful when you want a variable that will commute with other matrices, but can also be added to them.
+
+```python
+>>> # Sample 3x3 matrices consisting of a random number between 1 and 3 multiplying the identity
+>>> sampler = IdentityMatrixMultiples(dimension=3, sampler=[1, 3])
+>>> # The default is dimension=2 and sampler=[1, 5]
+>>> IdentityMatrixMultiples()
+
+```
+
 
 ## Variable Sampling: Generic
 
 ### DiscreteSet
 
-Sample from a discrete set of values, specified in a tuple. A single value may also be provided, but this case should usually be specified as a constant instead of as a sampling set.
+Sample from a discrete set of scalar values, specified in a tuple. A single value may also be provided, but this case should usually be specified as a constant instead of as a sampling set.
 
 ```python
 >>> # Select random numbers from (1, 3, 5, 7, 9)
@@ -116,7 +128,7 @@ Sample from a discrete set of values, specified in a tuple. A single value may a
 
 ### DependentSampler
 
-Compute a value for a variable based on the values of other variables. The sampler must be initialized with a list of variables that it depends on, as well as the formula used to perform the computation. The formula can use any base functions, but no user-defined functions. DependentSamplers can depend on other dependent variables. If you construct a self-referential chain, an error will occur.
+Compute a value for a variable based on the values of other variables. The sampler must be initialized with a list of variables that it depends on, as well as the formula used to perform the computation. The formula can use any base functions, but no user-defined functions. `DependentSampler`s can depend on other dependent variables. If you construct a self-referential chain, an error will occur. Note that `DependentSampler` can depend on vector/matrix quantities as well as scalars.
 
 ```python
 >>> # Set radius based on the random values of x, y and z

--- a/mitxgraders/sampling.py
+++ b/mitxgraders/sampling.py
@@ -222,7 +222,7 @@ class ComplexSector(ScalarSamplingSet):
         return self.modulus.gen_sample() * np.exp(1j * self.argument.gen_sample())
 
 
-class DiscreteSet(ScalarSamplingSet):  # pylint: disable=too-few-public-methods
+class DiscreteSet(VariableSamplingSet):  # pylint: disable=too-few-public-methods
     """
     Represents a discrete set of values from which to sample.
 

--- a/mitxgraders/sampling.py
+++ b/mitxgraders/sampling.py
@@ -392,7 +392,6 @@ class IdentityMatrixMultiples(AbstractSquareMatrices):
 
     The scalar multiple can be generated in a number of ways:
     >>> matrices = IdentityMatrixMultiples(sampler=[1,3])
-    >>> matrices = IdentityMatrixMultiples(sampler=(1, 3, 5))
     >>> sect = ComplexSector(modulus=[0,1], argument=[-np.pi,np.pi])
     >>> matrices = IdentityMatrixMultiples(sampler=sect)
 

--- a/mitxgraders/sampling.py
+++ b/mitxgraders/sampling.py
@@ -400,20 +400,18 @@ class IdentityMatrixMultiples(AbstractSquareMatrices):
     >>> matrices = IdentityMatrixMultiples()
     >>> m = matrices.gen_sample()
     >>> m == m[0, 0] * np.eye(2)
-    array([[ True,  True],
+    MathArray([[ True,  True],
            [ True,  True]], dtype=bool)
     """
 
     # Sampling set for the multiplicative constant
     # Accept anything that FormulaGrader would accept for a sampling set, restricted to
-    # scalar sampling sets. Hence, ScalarSamplingSets, ranges, and objects that can be
-    # coerced into discrete sets are allowed.
-    # Note: Does not support DependentSampler, as that is not guaranteed to return a
-    # scalar value.
+    # scalar sampling sets. Hence, ScalarSamplingSets and ranges are allowed.
+    # Note: Does not support DependentSampler or DiscreteSet, as they are not guaranteed
+    # to return a scalar value.
     schema_config = AbstractSquareMatrices.schema_config.extend({
         Required('sampler', default=RealInterval()): Any(ScalarSamplingSet,
-                                                         All(list, Coerce(RealInterval)),
-                                                         Coerce(DiscreteSet))
+                                                         All(list, Coerce(RealInterval)))
     })
 
     def gen_sample(self):
@@ -422,10 +420,10 @@ class IdentityMatrixMultiples(AbstractSquareMatrices):
         """
         # Sample the multiplicative constant
         scaling = self.config['sampler'].gen_sample()
-        # Create the matrix
-        matrix = scaling * np.eye(self.config['dimension'])
-        # Return the result
-        return matrix
+        # Create the numpy matrix
+        array = scaling * np.eye(self.config['dimension'])
+        # Return the result as a MathArray
+        return MathArray(array)
 
 
 class RandomFunction(FunctionSamplingSet):  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
This creates a sampler to sample matrices that are scalar multiples of the identity matrix. It determines that scalar by accepting another sampler. To do this, I added an extra abstract subclass of `VariableSamplingSet` called `ScalarSamplingSet`. I also created a new abstract class `AbstractSquareMatrices` that can be used to build up various special types of matrices. Documentation is included.