### PR TITLE
Quantum arrays

### DIFF
--- a/mitxgraders/helpers/validatorfuncs.py
+++ b/mitxgraders/helpers/validatorfuncs.py
@@ -62,6 +62,19 @@ def NumberRange(number_type=Number):
         number_range_alternate(number_type)
     ))
 
+def SubClassOf(parent_class):
+    """Demand a subclass of parent_class"""
+    def _validator(given_class):
+        try:
+            if issubclass(given_class, parent_class):
+                return given_class
+        except TypeError:
+            pass # Raise a voluptuous error below instead
+        msg = "Expected a subclass {parent_class.__name__}"
+        raise Invalid(msg.format(parent_class=parent_class))
+
+    return _validator
+
 def ListOfType(given_type, validator=None):
     """
     Validator that allows for a single given_type or a list of given_type.

--- a/mitxgraders/plugins/quantum_matharray.py
+++ b/mitxgraders/plugins/quantum_matharray.py
@@ -1,0 +1,26 @@
+from mitxgraders.helpers.calc import MathArray
+
+class QuantumMathArray(MathArray):
+
+    @property
+    def shape_name(self):
+        ndim = self.ndim
+        shape = self.shape
+
+        if ndim == 0:
+            return 'scalar'
+        elif ndim == 1:
+            return 'state vector'
+        elif ndim == 2:
+            if shape[0] == 1:
+                return 'bra'
+            elif shape[1] == 1:
+                return 'ket'
+            else:
+                return 'operator'
+        else:
+            return 'tensor'
+
+    @property
+    def description(self):
+        return self.shape_name

--- a/mitxgraders/sampling.py
+++ b/mitxgraders/sampling.py
@@ -29,7 +29,7 @@ from numbers import Number
 import abc
 import random
 import numpy as np
-from voluptuous import Schema, Required, All, Coerce, Any, Extra
+from voluptuous import Schema, Required, Optional, All, Coerce, Any, Extra
 from mitxgraders.baseclasses import ObjectWithSchema
 from mitxgraders.exceptions import ConfigError
 from mitxgraders.helpers.validatorfuncs import (
@@ -282,7 +282,7 @@ class RealMathArrays(VariableSamplingSet):
     schema_config = Schema({
         Required('shape'): is_shape_specification(min_dim=1),
         Required('norm', default=[1, 5]): NumberRange(),
-        Required('array_class'): SubClassOf(MathArray)
+        Optional('array_class'): SubClassOf(MathArray)
     })
 
     def __init__(self, config=None, **kwargs):

--- a/mitxgraders/sampling.py
+++ b/mitxgraders/sampling.py
@@ -34,7 +34,7 @@ from mitxgraders.baseclasses import ObjectWithSchema
 from mitxgraders.exceptions import ConfigError
 from mitxgraders.helpers.validatorfuncs import (
     Positive, NumberRange, ListOfType, TupleOfType, is_callable,
-    has_keys_of_type, is_shape_specification)
+    has_keys_of_type, is_shape_specification, SubClassOf)
 from mitxgraders.helpers.calc import (
     METRIC_SUFFIXES, CalcError, evaluator, MathArray)
 
@@ -281,7 +281,8 @@ class RealMathArrays(VariableSamplingSet):
 
     schema_config = Schema({
         Required('shape'): is_shape_specification(min_dim=1),
-        Required('norm', default=[1, 5]): NumberRange()
+        Required('norm', default=[1, 5]): NumberRange(),
+        Required('array_class'): SubClassOf(MathArray)
     })
 
     def __init__(self, config=None, **kwargs):
@@ -300,7 +301,11 @@ class RealMathArrays(VariableSamplingSet):
         array = np.random.random_sample(self.config['shape']) - 0.5
         actual_norm = np.linalg.norm(array)
         # convert the array to a matrix with desired norm
-        return MathArray(array) * desired_norm/actual_norm
+
+        # Using classes as default values in voluptuous seems to mangle the nice
+        # error messages, so set the default by hand
+        ArrayClass = self.config.get('array_class', MathArray)
+        return ArrayClass(array) * desired_norm/actual_norm
 
 
 class RealVectors(RealMathArrays):


### PR DESCRIPTION
This is meant as a proof-of-concept customizing MathArray error messages, as described in #183.

Here's an example:

```python
from mitxgraders.plugins.quantum_matharray import QuantumMathArray
from mitxgraders import MatrixGrader, RealMatrices, DependentSampler

grader = MatrixGrader(
    variables=['ket0', 'ket1', 'bra0', 'bra1'],
    sample_from={
        'ket0': RealMatrices(shape=(2, 1), array_class=QuantumMathArray),
        'ket1': RealMatrices(shape=(2, 1), array_class=QuantumMathArray),
        'bra0': DependentSampler(depends=['ket0'], formula='adj(ket0)'),
        'bra1': DependentSampler(depends=['ket1'], formula='adj(ket1)')
    }
)

grader('ket0*bra1', 'ket0 + bra1')
# MathArrayShapeError: Cannot add/subtract a ket with a bra.

# grader('ket0*bra1', 'ket0*bra1 + 1')
# MathArrayShapeError: Cannot add/subtract scalars to a operator.

# grader('ket0*bra1', 'sin(ket0*bra1)')
# DomainError: There was an error evaluating function sin(...)
# 1st input has an error: received a operator, expected a scalar

# grader('ket0*bra1', 'ket0*adj(ket1)')
# {'grade_decimal': 1, 'msg': '', 'ok': True}
```

The code is pretty simpler: just a `QuantumMathArray` is a sublcass of `MathArray` with customized `shape_name` and `description` properties.

@jolyonb Let me know what you think. Maybe worthwhile as a plugin for 8.06? If you decide to use it, the only change I would want to make is refactor slightly the matrix samplers to all use `array_class` consistently. (And, of course, use whatever names you actually want.)