### PR TITLE
fix bug partial credit for multi-answer ListGrader

### DIFF
--- a/mitxgraders/listgrader.py
+++ b/mitxgraders/listgrader.py
@@ -510,7 +510,18 @@ class ListGrader(AbstractGrader):
 
     @staticmethod
     def get_best_result(results):
-        """Compute the best result from a multi-input problem"""
+        """
+        Computes the best student result in multi-answer ListGrader problems.
+
+        Arguments:
+            results: a list of {'overall_message': '...', 'input_list': [...]}
+                dicts.
+
+        Returns:
+            The result in results which has the highest cumulative score. In the
+            case of ties, the result where high-scoring subparts occur early
+            is chosen.
+        """
         # If we had a single list of answers, just return the results
         if len(results) == 1:
             return results[0]
@@ -538,9 +549,10 @@ class ListGrader(AbstractGrader):
         # Find which of the culled results did best at each input
         max_vals = np.amax(culled_grades, axis=1)
         max_vals = np.array([max_vals]).T
-        high_scoring = culled_grades == max_vals
-        # high_scoring is a matrix the same shape as full_grades
-        # It stores True/False values for whether that result was the best for that input
+        high_scoring = (culled_grades == max_vals).T
+        # high_scoring is a matrix the same number of columns as full_grades
+        # It stores True/False values for whether that result was the best for
+        # that input, over the culled results
 
         # Run through the culled_grades matrix to figure out which results are still in
         # the running after each input

--- a/tests/test_listgrader.py
+++ b/tests/test_listgrader.py
@@ -227,6 +227,25 @@ def test_multiple_listAnswers():
     }
     assert result == expected_result
 
+def test_picking_between_equally_graded_results():
+    """Check that a listgrader with multiple equally-scoring answers picks
+    the one where high scores occur early"""
+    grader = ListGrader(
+        answers=(['a', 'b', 'c'], ['1', '2', '3']),
+        subgraders=StringGrader()
+    )
+
+    result = grader(None, ['wrong', 'b', '3'])
+    expected_result = {
+        'overall_message': '',
+        'input_list': [
+            {'ok': False, 'grade_decimal': 0, 'msg': ''},
+            {'ok': True, 'grade_decimal': 1.0, 'msg': ''},
+            {'ok': False, 'grade_decimal': 0, 'msg': ''}
+        ]
+    }
+    assert result == expected_result
+
 def test_multiple_listAnswers_same_grade():
     grader = ListGrader(
         answers=(


### PR DESCRIPTION
Fixes a bug where ListGraders was having trouble assigning partial credit to problems where `answers` was specified as a tuple of answers.

**Note:** The bugfix is really just transposing one matrix to fix a shape comparison. I believe the bug has gone undetected until now because our test case used 2 inputs and had 2 author-supplied answer, and transpose of a 2x2 is 2x2.

@jolyonb I believe this fixes the issue your 8.06 student encountered. I really would like to go over the code more carefully, add comments, etc, but you have an exam running and I'm about to get off my bus!  I did add a more descriptive docstring.


