### PR TITLE
Refactor comparers

### DIFF
--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -360,6 +360,16 @@ class ItemGrader(AbstractGrader):
         msg = value.get('msg', '')
         return {'ok': ok, 'msg': msg, 'grade_decimal': grade_decimal}
 
+    @staticmethod
+    def get_best_result(results):
+        """
+        Get the highest-scoring result with the longest feedback message.
+        """
+        best_score = max([r['grade_decimal'] for r in results])
+        best_results = [r for r in results if r['grade_decimal'] == best_score]
+        best_result_with_longest_msg = max(best_results, key=lambda r: len(r['msg']))
+        return best_result_with_longest_msg
+
     def check(self, answers, student_input, **kwargs):
         """
         Compares student input to each answer in answers, using check_response.
@@ -393,16 +403,13 @@ class ItemGrader(AbstractGrader):
         # Compute the results for each answer
         results = [self.check_response(answer, student_input, **kwargs) for answer in answers]
 
-        # Now find the best result for the student
-        best_score = max([r['grade_decimal'] for r in results])
-        best_results = [r for r in results if r['grade_decimal'] == best_score]
-        best_result_with_longest_msg = max(best_results, key=lambda r: len(r['msg']))
+        best_result = self.get_best_result(results)
 
         # Add in wrong_msg if appropriate
-        if best_result_with_longest_msg['msg'] == "" and best_score == 0:
-            best_result_with_longest_msg['msg'] = self.config["wrong_msg"]
+        if best_result['msg'] == "" and best_result['grade_decimal'] == 0:
+            best_result['msg'] = self.config["wrong_msg"]
 
-        return best_result_with_longest_msg
+        return best_result
 
     @abc.abstractmethod
     def check_response(self, answer, student_input, **kwargs):

--- a/mitxgraders/comparers/__init__.py
+++ b/mitxgraders/comparers/__init__.py
@@ -7,7 +7,7 @@ from comparers import (
     between_comparer,
     vector_span_comparer,
     vector_phase_comparer,
-    CorrellatedComparer,
+    CorrelatedComparer,
     constant_multiple_comparer,
     make_constant_multiple_comparer
 )
@@ -19,7 +19,7 @@ __all__ = [
     'between_comparer',
     'vector_span_comparer',
     'vector_phase_comparer',
-    'CorrellatedComparer',
+    'CorrelatedComparer',
     'constant_multiple_comparer',
     'make_constant_multiple_comparer'
 ]

--- a/mitxgraders/comparers/__init__.py
+++ b/mitxgraders/comparers/__init__.py
@@ -6,11 +6,11 @@ from comparers import (
     eigenvector_comparer,
     between_comparer,
     vector_span_comparer,
-    vector_phase_comparer,
-    CorrelatedComparer,
-    constant_multiple_comparer,
-    make_constant_multiple_comparer
+    vector_phase_comparer
 )
+from mitxgraders.comparers.baseclasses import CorrelatedComparer
+
+from mitxgraders.comparers.affine_comparer import AffineComparer
 
 __all__ = [
     'equality_comparer',

--- a/mitxgraders/comparers/__init__.py
+++ b/mitxgraders/comparers/__init__.py
@@ -6,7 +6,10 @@ from comparers import (
     eigenvector_comparer,
     between_comparer,
     vector_span_comparer,
-    vector_phase_comparer
+    vector_phase_comparer,
+    CorrellatedComparer,
+    constant_multiple_comparer,
+    make_constant_multiple_comparer
 )
 
 __all__ = [
@@ -15,5 +18,8 @@ __all__ = [
     'eigenvector_comparer',
     'between_comparer',
     'vector_span_comparer',
-    'vector_phase_comparer'
+    'vector_phase_comparer',
+    'CorrellatedComparer',
+    'constant_multiple_comparer',
+    'make_constant_multiple_comparer'
 ]

--- a/mitxgraders/comparers/affine_comparer.py
+++ b/mitxgraders/comparers/affine_comparer.py
@@ -1,0 +1,97 @@
+import numpy as np
+from voluptuous import Schema, Required, Any, All, Optional, Range
+from mitxgraders.comparers.baseclasses import CorrelatedComparer
+
+from mitxgraders.helpers.validatorfuncs import equals
+from mitxgraders.helpers.calc.mathfuncs import is_nearly_zero
+
+
+
+class AffineComparer(CorrelatedComparer):
+    """docstring for AffineComparer.""" #TODO
+
+    schema_config = Schema({
+        Required('mode', default='proportional'): Any('proportional', 'offset', 'affine'),
+        Required('grade_decimal', default=0.5): Range(0, 1),
+        Optional('msg'): str
+    })
+
+    default_messages = {
+        'proportional': 'The submitted answer differs from the expected answer by a constant factor.',
+        'offset': '',
+        'affine': ''
+    }
+
+    def get_message(self):
+        config_msg = self.config.get('msg', None)
+        mode = self.config['mode']
+
+        if config_msg is None:
+            return self.default_messages[mode]
+        return config_msg
+
+
+    def get_fit_error(self, comparer_params_evals, student_evals):
+        """
+
+        """
+
+        student = np.array(student_evals).flatten()
+        expected = np.array(comparer_params_evals).flatten()
+
+        if self.config['mode'] == 'proportional':
+            a = np.vstack(student)
+            b = expected
+            x, residuals, _, _ = np.linalg.lstsq(a, b, rcond=-1)
+        elif self.config['mode'] == 'affine':
+            a = np.vstack([student, np.ones(len(student))]).T
+            b = expected
+            x, residuals, _, _ = np.linalg.lstsq(a, b, rcond=-1)
+        elif self.config['mode'] == 'offset':
+            a = student
+            b = expected
+            mean = np.mean(a - b)
+            residuals = np.var(a + mean - b)
+
+
+        error = np.sqrt(residuals)
+
+        return error
+
+    def __call__(self, comparer_params_evals, student_evals, utils):
+        student_eval_norm = np.linalg.norm(student_evals)/len(student_evals)
+
+        # Validate student input shape...only needed for MatrixGrader
+        try:
+            utils.validate_shape(student_evals[0], comparer_params_evals[0][0].shape)
+        except AttributeError:
+            pass # not called by MatrixGrader
+
+        if is_nearly_zero(student_eval_norm, utils.tolerance, reference=student_evals):
+            return False
+
+        error = self.get_fit_error(comparer_params_evals, student_evals)
+
+        if is_nearly_zero(error, utils.tolerance, reference=student_eval_norm):
+            return {
+                'grade_decimal': self.config['grade_decimal'],
+                'msg': self.get_message()
+            }
+
+        return False
+
+# Used by FormulaGrader's Schema
+def affine_mode_schema(mode):
+    """
+    """ # TODO
+    return Any(
+        Schema({
+            Required('grade_decimal', default=0.5): Range(0, 1),
+            Optional('msg'): str,
+            Required('mode', default=mode): equals(mode)
+        }),
+        All(
+             Range(0, 1),
+            lambda x: {'grade_decimal': x, 'mode': mode}
+        )
+    )

--- a/mitxgraders/comparers/baseclasses.py
+++ b/mitxgraders/comparers/baseclasses.py
@@ -1,0 +1,23 @@
+import abc
+from mitxgraders.baseclasses import ObjectWithSchema
+
+class CorrelatedComparer(ObjectWithSchema):
+    """
+    CorrelatedComparer are callable objects used as comparer functions
+    in FormulaGrader problems. Unlike standard comparer functions, CorrelatedComparer
+    are given access to all parameter evaluations at once.
+
+    For example, a comparer function that decides whether the student input is a
+    nonzero constant multiple of the expected input would need to be a correlated
+    comparer so that it can determine if there is a linear relationship between
+    the student and expected samples.
+
+    This class is abstract. Correlated Comparers should inherit from it.
+    """
+
+    # This is an abstract base class
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def __call__(self, comparer_params_evals, student_evals, utils):
+        pass

--- a/mitxgraders/comparers/comparers.py
+++ b/mitxgraders/comparers/comparers.py
@@ -406,11 +406,19 @@ def make_constant_multiple_comparer(grade_decimal=0.5, msg='The submitted answer
     @CorrellatedComparer
     def _comparer(comparer_params_evals, student_evals, utils):
         student_eval_norm = np.linalg.norm(student_evals)/len(student_evals)
+
+        # Validate student input shape...only needed for MatrixGrader
+        try:
+            utils.validate_shape(student_evals[0], comparer_params_evals[0][0].shape)
+        except AttributeError:
+            pass # not called by MatrixGrader
+
         if is_nearly_zero(student_eval_norm, utils.tolerance, reference=student_evals):
             return False
 
-        A = np.vstack([student_evals]).T
-        y = [c[0] for c in comparer_params_evals]
+        A = np.vstack(np.array(student_evals).flatten())
+        y = np.array(comparer_params_evals).flatten()
+
         sol, residuals, _, _ = np.linalg.lstsq(A, y, rcond=-1)
         coeff = sol[0]
         error = np.sqrt(residuals)

--- a/mitxgraders/comparers/comparers.py
+++ b/mitxgraders/comparers/comparers.py
@@ -348,10 +348,10 @@ def vector_phase_comparer(comparer_params_evals, student_eval, utils):
 
     return in_span and same_magnitude
 
-class CorrellatedComparer(object):
+class CorrelatedComparer(object):
     """
     CorrelatedComparer instances are callable objects used as comparer functions
-    in FormulaGrader problems. Unlike standard comparer functions, CorrellatedComparer
+    in FormulaGrader problems. Unlike standard comparer functions, CorrelatedComparer
     instances are given access to all parameter evaluations at once.
 
     For example, a comparer function that decides whether the student input is a
@@ -403,7 +403,7 @@ def make_constant_multiple_comparer(grade_decimal=0.5, msg='The submitted answer
     """
 
 
-    @CorrellatedComparer
+    @CorrelatedComparer
     def _comparer(comparer_params_evals, student_evals, utils):
         student_eval_norm = np.linalg.norm(student_evals)/len(student_evals)
 

--- a/mitxgraders/comparers/comparers.py
+++ b/mitxgraders/comparers/comparers.py
@@ -45,6 +45,7 @@ NOTE: doctests in this module show how the comparer function would be used
 """
 from numbers import Number
 import numpy as np
+
 from mitxgraders.exceptions import InputTypeError, StudentFacingError
 from mitxgraders.helpers.calc.mathfuncs import is_nearly_zero
 from mitxgraders.helpers.calc.math_array import are_same_length_vectors, is_vector
@@ -347,89 +348,3 @@ def vector_phase_comparer(comparer_params_evals, student_eval, utils):
     same_magnitude = utils.within_tolerance(expected_mag, student_mag)
 
     return in_span and same_magnitude
-
-class CorrelatedComparer(object):
-    """
-    CorrelatedComparer instances are callable objects used as comparer functions
-    in FormulaGrader problems. Unlike standard comparer functions, CorrelatedComparer
-    instances are given access to all parameter evaluations at once.
-
-    For example, a comparer function that decides whether the student input is a
-    nonzero constant multiple of the expected input would need to be a correlated
-    comparer so that it can determine if there is a linear relationship between
-    the student and expected samples.
-    """
-
-    def __init__(self, func):
-        self._comparer = func
-
-    def __call__(self, comparer_params_evals, student_evals, utils):
-        return self._comparer(comparer_params_evals, student_evals, utils)
-
-def make_constant_multiple_comparer(grade_decimal=0.5, msg='The submitted answer differs from the expected answer by a constant multiple'):
-    """
-    Makes a comparer function that tests whether student input is a constant multiple
-    of expected input, and if so, gives partial credit and displays a message.
-
-    Usage
-    =====
-
-    >>> from mitxgraders import FormulaGrader
-    >>> grader = FormulaGrader(
-    ...     answers={
-    ...         'comparer_params': ['m*c^2'],
-    ...         'comparer': make_constant_multiple_comparer(grade_decimal=0.75)
-    ...     },
-    ...     variables=['m', 'c']
-    ... )
-    >>> result = grader(None, '2*m*c^2')
-    >>> result == {
-    ...     'ok': 'partial',
-    ...     'msg': 'The submitted answer differs from the expected answer by a constant multiple',
-    ...     'grade_decimal': 0.75
-    ... }
-    True
-
-
-    Gives full credit / no credit appropriately:
-    >>> grader(None, 'm*c^3')['ok']
-    False
-    >>> grader(None, 'm*c^2')['ok']
-    True
-
-    Zero input is always marked wrong:
-    >>> grader(None, '0')['ok']
-    False
-    """
-
-
-    @CorrelatedComparer
-    def _comparer(comparer_params_evals, student_evals, utils):
-        student_eval_norm = np.linalg.norm(student_evals)/len(student_evals)
-
-        # Validate student input shape...only needed for MatrixGrader
-        try:
-            utils.validate_shape(student_evals[0], comparer_params_evals[0][0].shape)
-        except AttributeError:
-            pass # not called by MatrixGrader
-
-        if is_nearly_zero(student_eval_norm, utils.tolerance, reference=student_evals):
-            return False
-
-        A = np.vstack(np.array(student_evals).flatten())
-        y = np.array(comparer_params_evals).flatten()
-
-        sol, residuals, _, _ = np.linalg.lstsq(A, y, rcond=-1)
-        coeff = sol[0]
-        error = np.sqrt(residuals)
-
-        if is_nearly_zero(error, utils.tolerance, reference=student_eval_norm):
-            if is_nearly_zero(coeff - 1, utils.tolerance, reference=student_eval_norm):
-                return True
-            return { 'grade_decimal': grade_decimal, 'msg': msg }
-
-        return False
-
-    return _comparer
-
-constant_multiple_comparer = make_constant_multiple_comparer()

--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -675,7 +675,7 @@ class FormulaGrader(ItemGrader):
     def gen_evaluations(self, comparer_params, student_input, sibling_formulas,
                         var_samples, func_samples):
         """
-        Evaluate the compaerer_params and student input.
+        Evaluate the comparer_params and student input.
 
         Returns:
             A tuple (list, list, set). The first two lists are comparer_params_evals
@@ -729,8 +729,7 @@ class FormulaGrader(ItemGrader):
 
         return comparer_params_evals, student_evals, meta.functions_used
 
-    @staticmethod
-    def compare_evaluations(compare_parms_evals, student_evals, comparer, utils, debug_logger):
+    def compare_evaluations(self, compare_parms_evals, student_evals, comparer, utils):
         """
         Compare the student evaluations to the expected results.
         """
@@ -743,8 +742,8 @@ class FormulaGrader(ItemGrader):
                 result = comparer(compare_parms_eval, student_eval, utils)
                 results.append(ItemGrader.standardize_cfn_return(result))
 
-        if debug_logger:
-            debug_logger(comparer, results)
+        if self.config['debug']:
+            self.log_comparison_info(comparer, results)
 
         return results
 
@@ -766,9 +765,8 @@ class FormulaGrader(ItemGrader):
 
         # Get the comparer function
         comparer = answer['expect']['comparer']
-        debug_logger = self.log_comparison_info if self.config['debug'] else None
         results = self.compare_evaluations(comparer_params_evals, student_evals,
-                                           comparer, self.comparer_utils, debug_logger)
+                                           comparer, self.comparer_utils)
 
         num_failures = 0
         for result in results:

--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -393,10 +393,15 @@ class FormulaGrader(ItemGrader):
         failable_evals (int): The number of samples that may disagree before the student's
             answer is marked incorrect (default 0)
 
-        answers (str | dict): A string, dictionary, or tuple thereof. If a string is supplied,
-            it represents the correct answer and is compared to student input for equality.
+        answers: A single "expect" value, a dictionary, or a tuple thereof, as
+            described in the documentation for ItemGraders.
 
-            If a dictionary is supplied, it needs keys:
+            The expect value can be a string, or can itself be a dictionary.
+
+            If the expect value is a string string, it represents the correct
+            answer and is compared to student input for equality.
+
+            If the expect value is a dictionary, it needs keys:
                 - comparer_params: a list of strings to be numerically sampled and passed to the
                     comparer function.
                 - comparer: a function with signature comparer(comparer_params_evals, student_eval,

--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -10,7 +10,7 @@ import re
 import itertools
 import numpy as np
 from voluptuous import Schema, Required, Any, All, Extra, Invalid, Length, Coerce
-from mitxgraders.comparers import equality_comparer, CorrellatedComparer
+from mitxgraders.comparers import equality_comparer, CorrelatedComparer
 from mitxgraders.sampling import (VariableSamplingSet, RealInterval, DiscreteSet,
                                   gen_symbols_samples, construct_functions,
                                   construct_constants, construct_suffixes,
@@ -735,7 +735,7 @@ class FormulaGrader(ItemGrader):
         Compare the student evaluations to the expected results.
         """
         results = []
-        if isinstance(comparer, CorrellatedComparer):
+        if isinstance(comparer, CorrelatedComparer):
             result = comparer(compare_parms_evals, student_evals, utils)
             results.append(ItemGrader.standardize_cfn_return(result))
         else:

--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -756,12 +756,12 @@ class FormulaGrader(ItemGrader):
         # required_siblings might include some extra variable names, but no matter
         sibling_formulas = self.get_sibling_formulas(siblings, required_siblings)
 
-        var_samples,func_samples = self.gen_var_and_func_samples(answer, student_input, sibling_formulas)
+        var_samples, func_samples = self.gen_var_and_func_samples(answer, student_input, sibling_formulas)
 
         (comparer_params_evals,
          student_evals,
-         functions_used) = self.gen_evaluations(comparer_params,student_input,
-                                      sibling_formulas, var_samples, func_samples)
+         functions_used) = self.gen_evaluations(comparer_params, student_input,
+                                                sibling_formulas, var_samples, func_samples)
 
         # Get the comparer function
         comparer = answer['expect']['comparer']

--- a/mitxgraders/helpers/validatorfuncs.py
+++ b/mitxgraders/helpers/validatorfuncs.py
@@ -347,3 +347,13 @@ def is_shape_specification(min_dim=1, max_dim=None):
         ),
         Length(min=min_dim, max=max_dim),
     )
+
+def equals(obj):
+    """
+    docstring
+    """ # TODO
+    def _validator(x):
+        if x != obj:
+            msg = "{x} is not {obj}".format(x=x, obj=obj)
+            raise Invalid(msg)
+    return _validator

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -498,7 +498,7 @@ def test_fg_debug_log():
     result = grader(None, 'z + x*x + f(y)')
 
     message = (
-    "<pre>MITx Grading Library Version 1.2.3<br/>\n"
+    "<pre>MITx Grading Library Version {version}<br/>\n"
     "Student Response:<br/>\n"
     "z + x*x + f(y)<br/>\n"
     "<br/>\n"

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -498,7 +498,7 @@ def test_fg_debug_log():
     result = grader(None, 'z + x*x + f(y)')
 
     message = (
-    "<pre>MITx Grading Library Version {version}<br/>\n"
+    "<pre>MITx Grading Library Version 1.2.3<br/>\n"
     "Student Response:<br/>\n"
     "z + x*x + f(y)<br/>\n"
     "<br/>\n"
@@ -561,8 +561,6 @@ def test_fg_debug_log():
     "    'z': (2.205526752143288+2.0897663659937935j)}}<br/>\n"
     "Student Eval: (14.7111745179+2.08976636599j)<br/>\n"
     "Compare to:  [(14.711174517877566+2.0897663659937935j)]<br/>\n"
-    "Comparer Function: <function equality_comparer at 0x...><br/>\n"
-    "Comparison Result: {{   'grade_decimal': 1.0, 'msg': '', 'ok': True}}<br/>\n"
     "<br/>\n"
     "<br/>\n"
     "==========================================<br/>\n"
@@ -578,8 +576,15 @@ def test_fg_debug_log():
     "    'z': (1.875174422525385+2.7835460015641598j)}}<br/>\n"
     "Student Eval: (11.9397106851+2.78354600156j)<br/>\n"
     "Compare to:  [(11.93971068506166+2.7835460015641598j)]<br/>\n"
+    "<br/>\n"
+    "<br/>\n"
+    "==========================================<br/>\n"
+    "Comparison Data for All 2 Samples<br/>\n"
+    "==========================================<br/>\n"
     "Comparer Function: <function equality_comparer at 0x...><br/>\n"
-    "Comparison Result: {{   'grade_decimal': 1.0, 'msg': '', 'ok': True}}<br/>\n"
+    "Comparison Results:<br/>\n"
+    "[   {{   'grade_decimal': 1.0, 'msg': '', 'ok': True}},<br/>\n"
+    "    {{   'grade_decimal': 1.0, 'msg': '', 'ok': True}}]<br/>\n"
     "</pre>"
     ).format(version=VERSION)
     assert result['msg'] == message


### PR DESCRIPTION
This PR addresses #193. The proposed API is:

```python
grader = FormulaGrader(
    answers={
        'comparer_params': ['m*c^2'],
        'comparer': make_constant_multiple_comparer(grade_decimal=0.75)
    },
    variables=['m', 'c']
)

grader(None, '2*m*c^3') # {'ok': False, 'grade_decimal': 0, 'msg': ''}
grader(None, '2*m*c^2') # {'ok': 'partial', 'grade_decimal': 0.75, 'msg': 'The submitted answer...' }
```

A few comments about implementation:
1. In the past, FormulaGrader would alternate between generating sample evaluations and comparing student input / expected answer: `eval, compare, eval, compare, ...`. This PR changes the behavior to generate all evaluations first: `eval, eval, eval ..., compare, compare, compare...`. This is slower on average but not in the worst case.
2. The standard usage of comparer functions still only allows comparing student / expected samples one at a time. If a comparer function is an instance of `CorrelatedComparer`, then it will be given access to all samples at once.
    - This was done for two reasons. First, to preserve backward compatibility. Second, I continue to believe that the one-by-one comparison suffices in most cases, and such comparer functions are easier to write. So it makes sense to keep that logic factored out.