### PR TITLE
Test docs

### DIFF
--- a/docs/grading_math/sampling.md
+++ b/docs/grading_math/sampling.md
@@ -90,7 +90,9 @@ Sample real matrices of a specific shape and norm. (`RealMatrices` uses the Frob
 >>> # Sample 3 by 2 real matrices with norm between 5 and 10
 >>> sampler = RealMatrices(shape=[3, 2], norm=[5, 10])
 >>> # the default is shape=[2, 2] and norm=[1, 5]
->>> RealMatrices()
+>>> default_sampler = RealMatrices()
+>>> default_sampler
+RealMatrices({'norm': [1, 5], 'shape': (2, 2)})
 
 ```
 
@@ -105,6 +107,7 @@ Sample square matrices of a given dimension consisting of the identity matrix mu
 >>> sampler = IdentityMatrixMultiples(dimension=3, sampler=[1, 3])
 >>> # The default is dimension=2 and sampler=[1, 5]
 >>> IdentityMatrixMultiples()
+IdentityMatrixMultiples({'dimension': 2, 'sampler': RealInterval({'start': 1, 'stop': 5})})
 
 ```
 
@@ -187,4 +190,5 @@ Finally, if you want to generate a complex random function, simply set `complex=
 
 ```python
 >>> functionsampler = RandomFunction(complex=True)
+
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,6 +135,7 @@ A few error messages serve only as warnings. For example, if you attempt to conf
 >>> grader = FormulaGrader(variables=['pi'])
 Traceback (most recent call last):
 ConfigError: Warning: 'variables' contains entries '['pi']' which will override default values. If you intend to override defaults, you may suppress this warning by adding 'suppress_warnings=True' to the grader configuration.
+
 ```
 
 As the warning message says, if you really want to override the default value of `'pi'` (not recommended!) then you can suppress this warning by setting `suppress_warnings=True`.

--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -9,6 +9,7 @@ Contains base classes for the library:
 from __future__ import division
 import numbers
 import abc
+import pprint
 from voluptuous import Schema, Required, All, Any, Range, MultipleInvalid
 from voluptuous.humanize import validate_with_humanized_errors as voluptuous_validate
 from mitxgraders.version import __version__
@@ -48,7 +49,11 @@ class ObjectWithSchema(object):
 
     def __repr__(self):
         """Printable representation of the object"""
-        return "{classname}({config})".format(classname=self.__class__.__name__, config=self.config)
+        # Among other things, pprint.pformat ensures the config dict has
+        # keys in alphabetical order
+        pretty_config = pprint.pformat(self.config)
+        return "{classname}({config})".format(classname=self.__class__.__name__,
+                                              config=pretty_config)
 
 class AbstractGrader(ObjectWithSchema):
     """

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --doctest-modules --cov=mitxgraders --cov-report=term-missing
-testpaths = tests mitxgraders
+addopts = --doctest-modules --cov=mitxgraders --cov-report=term-missing --doctest-glob='*.md'
+testpaths = tests mitxgraders docs


### PR DESCRIPTION
This makes `pytest` run the doc/*.md files as doc tests, and fixes a few broken tests.

To facilitate this, I made `ObjectWithSchema.__repr__` pretty-format its `config` dictionary before printing. Primarily, the goal there was to make sure keys are displayed in alphabetical order (which `pprint` does for dictionaries).
