### PR TITLE
Updating requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,43 +1,17 @@
-astroid==1.6.5
-atomicwrites==1.1.5
-attrs==18.1.0
-backports-abc==0.5
-backports.functools-lru-cache==1.5
-certifi==2018.4.16
-chardet==3.0.4
-click==6.7
-configparser==3.5.0
-coverage==4.5.1
-enum34==1.1.6
-funcsigs==1.0.2
-futures==3.2.0
-idna==2.7
-isort==4.3.4
-Jinja2==2.10
-lazy-object-proxy==1.3.1
-livereload==2.5.2
-Markdown==2.6.11
-MarkupSafe==1.0
-mccabe==0.6.1
-mkdocs==0.17.5
-mkdocs-cinder==0.11.0
-mock==2.0.0
-more-itertools==4.2.0
+# Used by the library (versions set to mirror edX)
 numpy==1.6.2
-pbr==4.0.4
-pluggy==0.6.0
-py==1.5.4
-pydeps==1.5.1
-pylint==1.9.2
 pyparsing==2.0.7
+scipy==0.14.0
+
+# For testing/linting
+mock
+pylint
 pytest==3.6.2
 pytest-cov==2.5.1
-PyYAML==3.13
-requests==2.19.1
-scipy==0.14.0
-singledispatch==3.4.0.3
-six==1.11.0
-stdlib-list==0.4.0
-tornado==4.5.3
-urllib3==1.23
-wrapt==1.10.11
+
+# For documentation
+mkdocs==0.17.5
+mkdocs-cinder
+
+# For uploading to edge
+requests


### PR DESCRIPTION
The aim of this is to comment and clean up `requirements.txt`, and hopefully reduce the number of messages that github sends us claiming that we have security vulnerabilities.

Resolves #195