### PR TITLE
Update volutpuous

### DIFF
--- a/docs/grading_math/sampling.md
+++ b/docs/grading_math/sampling.md
@@ -91,8 +91,8 @@ Sample real matrices of a specific shape and norm. (`RealMatrices` uses the Frob
 >>> sampler = RealMatrices(shape=[3, 2], norm=[5, 10])
 >>> # the default is shape=[2, 2] and norm=[1, 5]
 >>> default_sampler = RealMatrices()
->>> default_sampler
-RealMatrices({'norm': [1, 5], 'shape': (2, 2)})
+>>> default_sampler == RealMatrices(shape=[2, 2], norm=[1, 5])
+True
 
 ```
 

--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -55,6 +55,13 @@ class ObjectWithSchema(object):
         return "{classname}({config})".format(classname=self.__class__.__name__,
                                               config=pretty_config)
 
+    def __eq__(self, other):
+        """
+        Checks equality by checking class-equality and config equality.
+        """
+        return self.__class__ == other.__class__ and self.config == other.config
+
+
 class AbstractGrader(ObjectWithSchema):
     """
     Abstract grader class. All graders must build on this class.

--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -947,8 +947,8 @@ class NumericalGrader(FormulaGrader):
             Required('user_functions', default={}): {Extra: is_callable},
             Required('tolerance', default='5%'): Any(PercentageString, NonNegative(Number)),
             Required('samples', default=1): 1,
-            Required('variables', default=[]): [],
-            Required('numbered_vars', default=[]): [],
+            Required('variables', default=[]): All(Length(max=0), []),
+            Required('numbered_vars', default=[]): All(Length(max=0), []),
             Required('sample_from', default={}): {},
             Required('failable_evals', default=0): 0
         })

--- a/mitxgraders/formulagrader/matrixgrader.py
+++ b/mitxgraders/formulagrader/matrixgrader.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from voluptuous import Required, Any
 from mitxgraders.exceptions import InputTypeError
 from mitxgraders.formulagrader.formulagrader import FormulaGrader
-from mitxgraders.helpers.validatorfuncs import NonNegative
+from mitxgraders.helpers.validatorfuncs import NonNegative, Nullable
 from mitxgraders.helpers.calc import MathArray, within_tolerance, identity
 from mitxgraders.helpers.calc.exceptions import (
     MathArrayShapeError as ShapeError, MathArrayError, DomainError, ArgumentShapeError)
@@ -68,8 +68,8 @@ class MatrixGrader(FormulaGrader):
     def schema_config(self):
         schema = super(MatrixGrader, self).schema_config
         return schema.extend({
-            Required('identity_dim', default=None): NonNegative(int),
-            Required('max_array_dim', default=1): NonNegative(int),
+            Required('identity_dim', default=None): Nullable(NonNegative(int)),
+            Required('max_array_dim', default=1): Nullable(NonNegative(int)),
             Required('negative_powers', default=True): bool,
             Required('shape_errors', default=True): bool,
             Required('suppress_matrix_messages', default=False): bool,

--- a/mitxgraders/helpers/calc/specify_domain.py
+++ b/mitxgraders/helpers/calc/specify_domain.py
@@ -6,7 +6,7 @@ of a function. Currently only supports specifying the shape of inputs.
 """
 from numbers import Number
 from voluptuous import Schema, Invalid, Required, Any
-from mitxgraders.helpers.validatorfuncs import is_shape_specification
+from mitxgraders.helpers.validatorfuncs import is_shape_specification, Nullable
 from mitxgraders.baseclasses import ObjectWithSchema
 from mitxgraders.helpers.calc.exceptions import ArgumentShapeError, ArgumentError
 from mitxgraders.helpers.calc.math_array import (
@@ -189,7 +189,7 @@ class SpecifyDomain(ObjectWithSchema):
         Required('input_shapes'): [Schema(
             Any(is_shape_specification(), 'square')
         )],
-        Required('display_name', default=None): str
+        Required('display_name', default=None): Nullable(str)
     })
 
     def __init__(self, config=None, **kwargs):

--- a/mitxgraders/helpers/validatorfuncs.py
+++ b/mitxgraders/helpers/validatorfuncs.py
@@ -347,3 +347,9 @@ def is_shape_specification(min_dim=1, max_dim=None):
         ),
         Length(min=min_dim, max=max_dim),
     )
+
+def Nullable(schema):
+    """
+    Indicates that a value could be None or satisfy schema.
+    """
+    return Any(None, schema)

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -660,15 +660,15 @@ def test_ng_config():
             samples=2
         )
 
-    expect = "not a valid value for dictionary value @ data\['variables'\]. Got \['x'\]"
+    expect = "length of value must be at most 0 for dictionary value @ data\['variables'\]. Got \['x'\]"
     with raises(Error, match=expect):
         NumericalGrader(
             answers="1",
             variables=["x"]
         )
 
-    expect = "not a valid value for dictionary value @ data\['sample_from'\]. " + \
-             "Got {'x': RealInterval\({'start': 1, 'stop': 5}\)}"
+    expect = ("extra keys not allowed @ data\['sample_from'\]\['x'\]. Got "
+              "RealInterval\({'start': 1, 'stop': 5}\)")
     with raises(Error, match=expect):
         NumericalGrader(
             answers="1",

--- a/voluptuous/LICENSE
+++ b/voluptuous/LICENSE
@@ -1,5 +1,3 @@
-Voluptuous
-https://github.com/alecthomas/voluptuous
 Copyright (c) 2010, Alec Thomas
 All rights reserved.
 

--- a/voluptuous/__init__.py
+++ b/voluptuous/__init__.py
@@ -1,15 +1,9 @@
 # flake8: noqa
 
-try:
-    from schema_builder import *
-    from validators import *
-    from util import *
-    from error import *
-except ImportError:
-    from .schema_builder import *
-    from .validators import *
-    from .util import *
-    from .error import *
+from voluptuous.schema_builder import *
+from voluptuous.validators import *
+from voluptuous.util import *
+from voluptuous.error import *
 
-__version__ = '0.10.5'
-__author__ = 'tusharmakkar08'
+__version__ = '0.11.5'
+__author__ = 'alecthomas'

--- a/voluptuous/error.py
+++ b/voluptuous/error.py
@@ -187,3 +187,13 @@ class NotInInvalid(Invalid):
 
 class ExactSequenceInvalid(Invalid):
     pass
+
+
+class NotEnoughValid(Invalid):
+    """The value did not pass enough validations."""
+    pass
+
+
+class TooManyValid(Invalid):
+    """The value passed more than expected validations."""
+    pass

--- a/voluptuous/humanize.py
+++ b/voluptuous/humanize.py
@@ -1,4 +1,5 @@
-from voluptuous.error import Error, Invalid, MultipleInvalid
+from voluptuous import Invalid, MultipleInvalid
+from voluptuous.error import Error
 
 
 MAX_VALIDATION_ERROR_ITEM_LENGTH = 500

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -6,11 +6,7 @@ import sys
 from contextlib import contextmanager
 
 import itertools
-
-try:
-    import error as er
-except ImportError:
-    from . import error as er
+from voluptuous import error as er
 
 if sys.version_info >= (3,):
     long = int
@@ -25,6 +21,11 @@ else:
 
     def iteritems(d):
         return d.iteritems()
+
+if sys.version_info >= (3, 3):
+    _Mapping = collections.abc.Mapping
+else:
+    _Mapping = collections.Mapping
 
 """Schema validation for Python data structures.
 
@@ -126,6 +127,10 @@ class Undefined(object):
 UNDEFINED = Undefined()
 
 
+def Self():
+    raise er.SchemaError('"Self" should never be called')
+
+
 def default_factory(value):
     if value is UNDEFINED or callable(value):
         return value
@@ -201,11 +206,57 @@ class Schema(object):
         self.extra = int(extra)  # ensure the value is an integer
         self._compiled = self._compile(schema)
 
+    @classmethod
+    def infer(cls, data, **kwargs):
+        """Create a Schema from concrete data (e.g. an API response).
+
+        For example, this will take a dict like:
+
+        {
+            'foo': 1,
+            'bar': {
+                'a': True,
+                'b': False
+            },
+            'baz': ['purple', 'monkey', 'dishwasher']
+        }
+
+        And return a Schema:
+
+        {
+            'foo': int,
+            'bar': {
+                'a': bool,
+                'b': bool
+            },
+            'baz': [str]
+        }
+
+        Note: only very basic inference is supported.
+        """
+        def value_to_schema_type(value):
+            if isinstance(value, dict):
+                if len(value) == 0:
+                    return dict
+                return {k: value_to_schema_type(v)
+                        for k, v in iteritems(value)}
+            if isinstance(value, list):
+                if len(value) == 0:
+                    return list
+                else:
+                    return [value_to_schema_type(v)
+                            for v in value]
+            return type(value)
+
+        return cls(value_to_schema_type(data), **kwargs)
+
     def __eq__(self, other):
-        if str(other) == str(self.schema):
-            # Because repr is combination mixture of object and schema
-            return True
-        return False
+        if not isinstance(other, Schema):
+            return False
+        return other.schema == self.schema
+
+    def __ne__(self, other):
+        return not (self == other)
 
     def __str__(self):
         return str(self.schema)
@@ -228,16 +279,22 @@ class Schema(object):
     def _compile(self, schema):
         if schema is Extra:
             return lambda _, v: v
+        if schema is Self:
+            return lambda p, v: self._compiled(p, v)
+        elif hasattr(schema, "__voluptuous_compile__"):
+            return schema.__voluptuous_compile__(self)
         if isinstance(schema, Object):
             return self._compile_object(schema)
-        if isinstance(schema, collections.Mapping) and len(schema):
+        if isinstance(schema, _Mapping):
             return self._compile_dict(schema)
-        elif isinstance(schema, list) and len(schema):
+        elif isinstance(schema, list):
             return self._compile_list(schema)
         elif isinstance(schema, tuple):
             return self._compile_tuple(schema)
+        elif isinstance(schema, (frozenset, set)):
+            return self._compile_set(schema)
         type_ = type(schema)
-        if type_ is type:
+        if inspect.isclass(schema):
             type_ = schema
         if type_ in (bool, bytes, int, long, str, unicode, float, complex, object,
                      list, dict, type(None)) or callable(schema):
@@ -284,11 +341,25 @@ class Schema(object):
 
         def validate_mapping(path, iterable, out):
             required_keys = all_required_keys.copy()
-            # keeps track of all default keys that haven't been filled
-            default_keys = all_default_keys.copy()
+
+            # Build a map of all provided key-value pairs.
+            # The type(out) is used to retain ordering in case a ordered
+            # map type is provided as input.
+            key_value_map = type(out)()
+            for key, value in iterable:
+                key_value_map[key] = value
+
+            # Insert default values for non-existing keys.
+            for key in all_default_keys:
+                if not isinstance(key.default, Undefined) and \
+                   key.schema not in key_value_map:
+                    # A default value has been specified for this missing
+                    # key, insert it.
+                    key_value_map[key.schema] = key.default()
+
             error = None
             errors = []
-            for key, value in iterable:
+            for key, value in key_value_map.items():
                 key_path = path + [key]
                 remove_key = False
 
@@ -338,11 +409,9 @@ class Schema(object):
                         required_keys.discard(skey)
                         break
 
-                    # Key and value okay, mark any Required() fields as found.
+                    # Key and value okay, mark as found in case it was
+                    # a Required() field.
                     required_keys.discard(skey)
-
-                    # No need for a default if it was filled
-                    default_keys.discard(skey)
 
                     break
                 else:
@@ -354,13 +423,6 @@ class Schema(object):
                     elif self.extra != REMOVE_EXTRA:
                         errors.append(er.Invalid('extra keys not allowed', key_path))
                         # else REMOVE_EXTRA: ignore the key so it's removed from output
-
-            # set defaults for any that can have defaults
-            for key in default_keys:
-                if not isinstance(key.default, Undefined):  # if the user provides a default with the node
-                    out[key.schema] = key.default()
-                    if key in required_keys:
-                        required_keys.discard(key)
 
             # for any required keys left that weren't found and don't have defaults:
             for key in required_keys:
@@ -412,7 +474,7 @@ class Schema(object):
 
         A dictionary schema will only validate a dictionary:
 
-            >>> validate = Schema({'prop': str})
+            >>> validate = Schema({})
             >>> with raises(er.MultipleInvalid, 'expected a dictionary'):
             ...   validate([])
 
@@ -427,6 +489,7 @@ class Schema(object):
             >>> with raises(er.MultipleInvalid, "extra keys not allowed @ data['two']"):
             ...   validate({'two': 'three'})
 
+
         Validation function, in this case the "int" type:
 
             >>> validate = Schema({'one': 'two', 'three': 'four', int: str})
@@ -436,17 +499,10 @@ class Schema(object):
             >>> validate({10: 'twenty'})
             {10: 'twenty'}
 
-        An empty dictionary is matched as value:
-
-            >>> validate = Schema({})
-            >>> with raises(er.MultipleInvalid, 'not a valid value'):
-            ...   validate([])
-
         By default, a "type" in the schema (in this case "int") will be used
         purely to validate that the corresponding value is of that type. It
         will not Coerce the value:
 
-            >>> validate = Schema({'one': 'two', 'three': 'four', int: str})
             >>> with raises(er.MultipleInvalid, "extra keys not allowed @ data['10']"):
             ...   validate({'10': 'twenty'})
 
@@ -561,6 +617,10 @@ class Schema(object):
 
             # Empty seq schema, allow any data.
             if not schema:
+                if data:
+                    raise er.MultipleInvalid([
+                        er.ValueInvalid('not a valid value', [value]) for value in data
+                    ])
                 return data
 
             out = []
@@ -622,6 +682,46 @@ class Schema(object):
         """
         return self._compile_sequence(schema, list)
 
+    def _compile_set(self, schema):
+        """Validate a set.
+
+        A set is an unordered collection of unique elements.
+
+        >>> validator = Schema({int})
+        >>> validator(set([42])) == set([42])
+        True
+        >>> with raises(er.Invalid, 'expected a set'):
+        ...   validator(42)
+        >>> with raises(er.MultipleInvalid, 'invalid value in set'):
+        ...   validator(set(['a']))
+        """
+        type_ = type(schema)
+        type_name = type_.__name__
+
+        def validate_set(path, data):
+            if not isinstance(data, type_):
+                raise er.Invalid('expected a %s' % type_name, path)
+
+            _compiled = [self._compile(s) for s in schema]
+            errors = []
+            for value in data:
+                for validate in _compiled:
+                    try:
+                        validate(path, value)
+                        break
+                    except er.Invalid:
+                        pass
+                else:
+                    invalid = er.Invalid('invalid value in %s' % type_name, path)
+                    errors.append(invalid)
+
+            if errors:
+                raise er.MultipleInvalid(errors)
+
+            return data
+
+        return validate_set
+
     def extend(self, schema, required=None, extra=None):
         """Create a new `Schema` by merging this and the provided `schema`.
 
@@ -676,9 +776,10 @@ class Schema(object):
                 result[key] = value
 
         # recompile and send old object
+        result_cls = type(self)
         result_required = (required if required is not None else self.required)
         result_extra = (extra if extra is not None else self.extra)
-        return Schema(result, required=result_required, extra=result_extra)
+        return result_cls(result, required=result_required, extra=result_extra)
 
 
 def _compile_scalar(schema):
@@ -700,7 +801,7 @@ def _compile_scalar(schema):
     >>> with raises(er.Invalid, 'not a valid value'):
     ...   _compile_scalar(lambda v: float(v))([], 'a')
     """
-    if isinstance(schema, type):
+    if inspect.isclass(schema):
         def validate_instance(path, data):
             if isinstance(data, schema):
                 return data
@@ -803,7 +904,6 @@ def _iterate_object(obj):
         for key in slots:
             if key != '__dict__':
                 yield (key, getattr(obj, key))
-    raise StopIteration()
 
 
 class Msg(object):
@@ -879,10 +979,11 @@ class VirtualPathComponent(str):
 class Marker(object):
     """Mark nodes for special treatment."""
 
-    def __init__(self, schema_, msg=None):
+    def __init__(self, schema_, msg=None, description=None):
         self.schema = schema_
         self._schema = Schema(schema_)
         self.msg = msg
+        self.description = description
 
     def __call__(self, v):
         try:
@@ -899,7 +1000,9 @@ class Marker(object):
         return repr(self.schema)
 
     def __lt__(self, other):
-        return self.schema < other.schema
+        if isinstance(other, Marker):
+            return self.schema < other.schema
+        return self.schema < other
 
     def __hash__(self):
         return hash(self.schema)
@@ -934,8 +1037,9 @@ class Optional(Marker):
     {'key2': 'value'}
     """
 
-    def __init__(self, schema, msg=None, default=UNDEFINED):
-        super(Optional, self).__init__(schema, msg=msg)
+    def __init__(self, schema, msg=None, default=UNDEFINED, description=None):
+        super(Optional, self).__init__(schema, msg=msg,
+                                       description=description)
         self.default = default_factory(default)
 
 
@@ -975,8 +1079,9 @@ class Exclusive(Optional):
     ...             'social': {'social_network': 'barfoo', 'token': 'tEMp'}})
     """
 
-    def __init__(self, schema, group_of_exclusion, msg=None):
-        super(Exclusive, self).__init__(schema, msg=msg)
+    def __init__(self, schema, group_of_exclusion, msg=None, description=None):
+        super(Exclusive, self).__init__(schema, msg=msg,
+                                        description=description)
         self.group_of_exclusion = group_of_exclusion
 
 
@@ -1022,8 +1127,11 @@ class Inclusive(Optional):
     True
     """
 
-    def __init__(self, schema, group_of_inclusion, msg=None):
-        super(Inclusive, self).__init__(schema, msg=msg)
+    def __init__(self, schema, group_of_inclusion,
+                 msg=None, description=None, default=UNDEFINED):
+        super(Inclusive, self).__init__(schema, msg=msg,
+                                        default=default,
+                                        description=description)
         self.group_of_inclusion = group_of_inclusion
 
 
@@ -1042,8 +1150,9 @@ class Required(Marker):
     {'key': []}
     """
 
-    def __init__(self, schema, msg=None, default=UNDEFINED):
-        super(Required, self).__init__(schema, msg=msg)
+    def __init__(self, schema, msg=None, default=UNDEFINED, description=None):
+        super(Required, self).__init__(schema, msg=msg,
+                                       description=description)
         self.default = default_factory(default)
 
 
@@ -1071,6 +1180,7 @@ class Remove(Marker):
 
     def __hash__(self):
         return object.__hash__(self)
+
 
 def message(default=None, cls=None):
     """Convenience decorator to allow functions to provide a message.
@@ -1174,7 +1284,8 @@ def validate(*a, **kw):
             returns = schema_arguments[RETURNS_KEY]
             del schema_arguments[RETURNS_KEY]
 
-        input_schema = Schema(schema_arguments) if len(schema_arguments) != 0 else lambda x: x
+        input_schema = (Schema(schema_arguments, extra=ALLOW_EXTRA)
+                        if len(schema_arguments) != 0 else lambda x: x)
         output_schema = Schema(returns) if returns_defined else lambda x: x
 
         @wraps(func)

--- a/voluptuous/util.py
+++ b/voluptuous/util.py
@@ -1,15 +1,18 @@
 import sys
 
-try:
-    from error import LiteralInvalid, TypeInvalid, Invalid
-    from schema_builder import Schema, default_factory, raises
-    import validators
-except ImportError:
-    from .error import LiteralInvalid, TypeInvalid, Invalid
-    from .schema_builder import Schema, default_factory, raises
-    from . import validators
+from voluptuous.error import LiteralInvalid, TypeInvalid, Invalid
+from voluptuous.schema_builder import Schema, default_factory, raises
+from voluptuous import validators
 
 __author__ = 'tusharmakkar08'
+
+
+def _fix_str(v):
+    if sys.version_info[0] == 2 and isinstance(v, unicode):
+        s = v
+    else:
+        s = str(v)
+    return s
 
 
 def Lower(v):
@@ -19,7 +22,7 @@ def Lower(v):
     >>> s('HI')
     'hi'
     """
-    return str(v).lower()
+    return _fix_str(v).lower()
 
 
 def Upper(v):
@@ -29,7 +32,7 @@ def Upper(v):
     >>> s('hi')
     'HI'
     """
-    return str(v).upper()
+    return _fix_str(v).upper()
 
 
 def Capitalize(v):
@@ -39,7 +42,7 @@ def Capitalize(v):
     >>> s('hello world')
     'Hello world'
     """
-    return str(v).capitalize()
+    return _fix_str(v).capitalize()
 
 
 def Title(v):
@@ -49,7 +52,7 @@ def Title(v):
     >>> s('hello world')
     'Hello World'
     """
-    return str(v).title()
+    return _fix_str(v).title()
 
 
 def Strip(v):
@@ -59,7 +62,7 @@ def Strip(v):
     >>> s('  hello world  ')
     'hello world'
     """
-    return str(v).strip()
+    return _fix_str(v).strip()
 
 
 class DefaultTo(object):

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -5,22 +5,16 @@ import sys
 from functools import wraps
 from decimal import Decimal, InvalidOperation
 
-try:
-    from schema_builder import Schema, raises, message
-    from error import (MultipleInvalid, CoerceInvalid, TrueInvalid, FalseInvalid, BooleanInvalid, Invalid, AnyInvalid,
-                       AllInvalid, MatchInvalid, UrlInvalid, EmailInvalid, FileInvalid, DirInvalid, RangeInvalid,
-                       PathInvalid, ExactSequenceInvalid, LengthInvalid, DatetimeInvalid, DateInvalid, InInvalid,
-                       TypeInvalid, NotInInvalid, ContainsInvalid)
-except ImportError:
-    from .schema_builder import Schema, raises, message
-    from .error import (MultipleInvalid, CoerceInvalid, TrueInvalid, FalseInvalid, BooleanInvalid, Invalid, AnyInvalid,
-                        AllInvalid, MatchInvalid, UrlInvalid, EmailInvalid, FileInvalid, DirInvalid, RangeInvalid,
-                        PathInvalid, ExactSequenceInvalid, LengthInvalid, DatetimeInvalid, DateInvalid, InInvalid,
-                        TypeInvalid, NotInInvalid, ContainsInvalid)
-
+from voluptuous.schema_builder import Schema, raises, message
+from voluptuous.error import (MultipleInvalid, CoerceInvalid, TrueInvalid, FalseInvalid, BooleanInvalid, Invalid,
+                              AnyInvalid, AllInvalid, MatchInvalid, UrlInvalid, EmailInvalid, FileInvalid, DirInvalid,
+                              RangeInvalid, PathInvalid, ExactSequenceInvalid, LengthInvalid, DatetimeInvalid,
+                              DateInvalid, InInvalid, TypeInvalid, NotInInvalid, ContainsInvalid, NotEnoughValid,
+                              TooManyValid)
 
 if sys.version_info >= (3,):
     import urllib.parse as urlparse
+
     basestring = str
 else:
     import urlparse
@@ -99,7 +93,7 @@ class Coerce(object):
     def __call__(self, v):
         try:
             return self.type(v)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, InvalidOperation):
             msg = self.msg or ('expected %s' % self.type_name)
             raise CoerceInvalid(msg)
 
@@ -187,7 +181,41 @@ def Boolean(v):
     return bool(v)
 
 
-class Any(object):
+class _WithSubValidators(object):
+    """Base class for validators that use sub-validators.
+
+    Special class to use as a parent class for validators using sub-validators.
+    This class provides the `__voluptuous_compile__` method so the
+    sub-validators are compiled by the parent `Schema`.
+    """
+
+    def __init__(self, *validators, **kwargs):
+        self.validators = validators
+        self.msg = kwargs.pop('msg', None)
+        self.required = kwargs.pop('required', False)
+
+    def __voluptuous_compile__(self, schema):
+        self._compiled = []
+        for v in self.validators:
+            schema.required = self.required
+            self._compiled.append(schema._compile(v))
+        return self._run
+
+    def _run(self, path, value):
+        return self._exec(self._compiled, value, path)
+
+    def __call__(self, v):
+        return self._exec((Schema(val) for val in self.validators), v)
+
+    def __repr__(self):
+        return '%s(%s, msg=%r)' % (
+            self.__class__.__name__,
+            ", ".join(repr(v) for v in self.validators),
+            self.msg
+        )
+
+
+class Any(_WithSubValidators):
     """Use the first validated value.
 
     :param msg: Message to deliver to user if validation fails.
@@ -212,33 +240,30 @@ class Any(object):
     ...   validate(4)
     """
 
-    def __init__(self, *validators, **kwargs):
-        self.validators = validators
-        self.msg = kwargs.pop('msg', None)
-        self._schemas = [Schema(val, **kwargs) for val in validators]
-
-    def __call__(self, v):
+    def _exec(self, funcs, v, path=None):
         error = None
-        for schema in self._schemas:
+        for func in funcs:
             try:
-                return schema(v)
+                if path is None:
+                    return func(v)
+                else:
+                    return func(path, v)
             except Invalid as e:
                 if error is None or len(e.path) > len(error.path):
                     error = e
         else:
             if error:
-                raise error if self.msg is None else AnyInvalid(self.msg)
-            raise AnyInvalid(self.msg or 'no valid value found')
-
-    def __repr__(self):
-        return 'Any([%s])' % (", ".join(repr(v) for v in self.validators))
+                raise error if self.msg is None else AnyInvalid(
+                    self.msg, path=path)
+            raise AnyInvalid(self.msg or 'no valid value found',
+                             path=path)
 
 
 # Convenience alias
 Or = Any
 
 
-class All(object):
+class All(_WithSubValidators):
     """Value must pass all validators.
 
     The output of each validator is passed as input to the next.
@@ -251,24 +276,16 @@ class All(object):
     10
     """
 
-    def __init__(self, *validators, **kwargs):
-        self.validators = validators
-        self.msg = kwargs.pop('msg', None)
-        self._schemas = [Schema(val, **kwargs) for val in validators]
-
-    def __call__(self, v):
+    def _exec(self, funcs, v, path=None):
         try:
-            for schema in self._schemas:
-                v = schema(v)
+            for func in funcs:
+                if path is None:
+                    v = func(v)
+                else:
+                    v = func(path, v)
         except Invalid as e:
-            raise e if self.msg is None else AllInvalid(self.msg)
+            raise e if self.msg is None else AllInvalid(self.msg, path=path)
         return v
-
-    def __repr__(self):
-        return 'All(%s, msg=%r)' % (
-            ", ".join(repr(v) for v in self.validators),
-            self.msg
-        )
 
 
 # Convenience alias
@@ -419,9 +436,13 @@ def IsFile(v):
     >>> with raises(FileInvalid, 'Not a file'):
     ...   IsFile()(None)
     """
-    if v:
-        return os.path.isfile(v)
-    else:
+    try:
+        if v:
+            v = str(v)
+            return os.path.isfile(v)
+        else:
+            raise FileInvalid('Not a file')
+    except TypeError:
         raise FileInvalid('Not a file')
 
 
@@ -435,9 +456,13 @@ def IsDir(v):
     >>> with raises(DirInvalid, 'Not a directory'):
     ...   IsDir()(None)
     """
-    if v:
-        return os.path.isdir(v)
-    else:
+    try:
+        if v:
+            v = str(v)
+            return os.path.isdir(v)
+        else:
+            raise DirInvalid("Not a directory")
+    except TypeError:
         raise DirInvalid("Not a directory")
 
 
@@ -453,16 +478,21 @@ def PathExists(v):
     >>> with raises(PathInvalid, 'Not a Path'):
     ...   PathExists()(None)
     """
-    if v:
-        return os.path.exists(v)
-    else:
+    try:
+        if v:
+            v = str(v)
+            return os.path.exists(v)
+        else:
+            raise PathInvalid("Not a Path")
+    except TypeError:
         raise PathInvalid("Not a Path")
 
 
-class Maybe(object):
-    """Validate that the object is of a given type or is None.
+def Maybe(validator, msg=None):
+    """Validate that the object matches given validator or is None.
 
-    :raises Invalid: if the value is not of the type declared and is not None
+    :raises Invalid: if the value does not match the given validator and is not
+        None
 
     >>> s = Schema(Maybe(int))
     >>> s(10)
@@ -471,21 +501,7 @@ class Maybe(object):
     ...  s("string")
 
     """
-    def __init__(self, kind, msg=None):
-        if not isinstance(kind, type):
-            raise TypeError("kind has to be a type")
-
-        self.kind = kind
-        self.msg = msg
-
-    def __call__(self, v):
-        if v is not None and not isinstance(v, self.kind):
-            raise Invalid(self.msg or "%s must be None or of type %s" % (v, self.kind))
-
-        return v
-
-    def __repr__(self):
-        return 'Maybe(%s)' % str(self.kind)
+    return Any(None, validator, msg=msg)
 
 
 class Range(object):
@@ -621,15 +637,10 @@ class Date(Datetime):
     """Validate that the value matches the date format."""
 
     DEFAULT_FORMAT = '%Y-%m-%d'
-    FORMAT_DESCRIPTION = 'yyyy-mm-dd'
 
     def __call__(self, v):
         try:
             datetime.datetime.strptime(v, self.format)
-            if len(v) != len(self.FORMAT_DESCRIPTION):
-                raise DateInvalid(
-                    self.msg or 'value has invalid length'
-                                ' expected length %d (%s)' % (len(self.FORMAT_DESCRIPTION), self.FORMAT_DESCRIPTION))
         except (TypeError, ValueError):
             raise DateInvalid(
                 self.msg or 'value does not match'
@@ -704,7 +715,7 @@ class Contains(object):
         return v
 
     def __repr__(self):
-        return 'Contains(%s)' % (self.item, )
+        return 'Contains(%s)' % (self.item,)
 
 
 class ExactSequence(object):
@@ -866,10 +877,8 @@ class Unordered(object):
             el = missing[0]
             raise Invalid(self.msg or 'Element #{} ({}) is not valid against any validator'.format(el[0], el[1]))
         elif missing:
-            raise MultipleInvalid([
-                Invalid(self.msg or 'Element #{} ({}) is not valid against any validator'.format(el[0], el[1]))
-                for el in missing
-            ])
+            raise MultipleInvalid([Invalid(self.msg or 'Element #{} ({}) is not valid against any validator'.format(
+                el[0], el[1])) for el in missing])
         return v
 
     def __repr__(self):
@@ -904,15 +913,16 @@ class Number(object):
         """
         precision, scale, decimal_num = self._get_precision_scale(v)
 
-        if self.precision is not None and self.scale is not None and\
-            precision != self.precision and scale != self.scale:
-            raise Invalid(self.msg or "Precision must be equal to %s, and Scale must be equal to %s" %(self.precision, self.scale))
+        if self.precision is not None and self.scale is not None and precision != self.precision\
+                and scale != self.scale:
+            raise Invalid(self.msg or "Precision must be equal to %s, and Scale must be equal to %s" % (self.precision,
+                                                                                                        self.scale))
         else:
             if self.precision is not None and precision != self.precision:
-                raise Invalid(self.msg or "Precision must be equal to %s"%self.precision)
+                raise Invalid(self.msg or "Precision must be equal to %s" % self.precision)
 
-            if self.scale is not None and scale != self.scale :
-                raise Invalid(self.msg or "Scale must be equal to %s"%self.scale)
+            if self.scale is not None and scale != self.scale:
+                raise Invalid(self.msg or "Scale must be equal to %s" % self.scale)
 
         if self.yield_decimal:
             return decimal_num
@@ -933,3 +943,63 @@ class Number(object):
             raise Invalid(self.msg or 'Value must be a number enclosed with string')
 
         return (len(decimal_num.as_tuple().digits), -(decimal_num.as_tuple().exponent), decimal_num)
+
+
+class SomeOf(_WithSubValidators):
+    """Value must pass at least some validations, determined by the given parameter.
+    Optionally, number of passed validations can be capped.
+
+    The output of each validator is passed as input to the next.
+
+    :param min_valid: Minimum number of valid schemas.
+    :param validators: a list of schemas or validators to match input against
+    :param max_valid: Maximum number of valid schemas.
+    :param msg: Message to deliver to user if validation fails.
+    :param kwargs: All other keyword arguments are passed to the sub-Schema constructors.
+
+    :raises NotEnoughValid: if the minimum number of validations isn't met
+    :raises TooManyValid: if the more validations than the given amount is met
+
+    >>> validate = Schema(SomeOf(min_valid=2, validators=[Range(1, 5), Any(float, int), 6.6]))
+    >>> validate(6.6)
+    6.6
+    >>> validate(3)
+    3
+    >>> with raises(MultipleInvalid, 'value must be at most 5, not a valid value'):
+    ...     validate(6.2)
+    """
+
+    def __init__(self, validators, min_valid=None, max_valid=None, **kwargs):
+        assert min_valid is not None or max_valid is not None, \
+            'when using "%s" you should specify at least one of min_valid and max_valid' % (type(self).__name__,)
+        self.min_valid = min_valid or 0
+        self.max_valid = max_valid or len(validators)
+        super(SomeOf, self).__init__(*validators, **kwargs)
+
+    def _exec(self, funcs, v, path=None):
+        errors = []
+        funcs = list(funcs)
+        for func in funcs:
+            try:
+                if path is None:
+                    v = func(v)
+                else:
+                    v = func(path, v)
+            except Invalid as e:
+                errors.append(e)
+
+        passed_count = len(funcs) - len(errors)
+        if self.min_valid <= passed_count <= self.max_valid:
+            return v
+
+        msg = self.msg
+        if not msg:
+            msg = ', '.join(map(str, errors))
+
+        if passed_count > self.max_valid:
+            raise TooManyValid(msg)
+        raise NotEnoughValid(msg)
+
+    def __repr__(self):
+        return 'SomeOf(min_valid=%s, validators=[%s], max_valid=%s, msg=%r)' % (
+            self.min_valid, ", ".join(repr(v) for v in self.validators), self.max_valid, self.msg)


### PR DESCRIPTION
Updates voluptuous to version `0.11.5`.

Largely, this update is motivated by my desire to validate default values in dictionaries. In particular, some of our validators also transform the input. I was surprised today by:

```python
from mitxgraders import RealMatrices

x = RealMatrices()
y = RealMatrices({'norm': [1, 5], 'shape': (2, 2)})

print(x) # RealMatrices({'norm': [1, 5], 'shape': (2, 2)})
print(y) # RealMatrices({'norm': {'start': 1, 'stop': 5}, 'shape': (2, 2)})
```