### PR TITLE
Updating SingleListGrader to detect missing entries

### DIFF
--- a/docs/grading_lists/single_list_grader.md
+++ b/docs/grading_lists/single_list_grader.md
@@ -2,18 +2,26 @@
 
 If you want a response to be a delimiter-separated list of items, you can use a special ItemGrader called `SingleListGrader` to perform the grading. You need to specify a subgrader (which must be an ItemGrader, and could even be another SingleListGrader) to evaluate each individual item. The basic usage is as follows.
 
-```python
-grader = SingleListGrader(
-    answers=['cat', 'dog'],
-    subgrader=StringGrader()
-)
+```pycon
+>>> from mitxgraders import *
+>>> grader = SingleListGrader(
+...     answers=['cat', 'dog'],
+...     subgrader=StringGrader()
+... )
+>>> grader(None, 'cat, dog') == {'grade_decimal': 1.0, 'msg': '', 'ok': True}
+True
+>>> grader(None, 'dog, cat') == {'grade_decimal': 1.0, 'msg': '', 'ok': True}
+True
+>>> grader(None, 'cat, octopus') == {'grade_decimal': 0.5, 'msg': '', 'ok': 'partial'}
+True
+
 ```
 
 To receive full points for this problem, a student would enter `cat, dog` or `dog, cat` into the input box. Entering `cat, octopus` or just `cat` will receive half points. The `answers` key is a python list of the individual answers you wish to use.
 
 You can use a tuple of lists to specify multiple lists of answers, just like normal ItemGraders.
 
-```python
+```pycon
 grader = SingleListGrader(
     answers=(
         [('cat', 'feline'), 'dog'],
@@ -30,7 +38,7 @@ Now, `cat, dog` and `goat, vole` will get full grades. But mixes won't: `cat, vo
 
 By default a SingleListGrader doesn't care which order the input is given in. If you want the answers and the student input to be compared in order, set `ordered=True`.
 
-```python
+```pycon
 grader = SingleListGrader(
     answers=['cat', 'dog'],
     subgrader=StringGrader(),
@@ -45,7 +53,7 @@ Now `cat, dog` will receive full grades, but `dog, cat` will be marked wrong. No
 
 If students are asked to enter a list of three items but only enter two, should this use up an attempt, or present an error message? If you want to present an error message, turn on length checking.
 
-```python
+```pycon
 grader = SingleListGrader(
     answers=['cat', 'dog'],
     subgrader=StringGrader(),
@@ -55,14 +63,39 @@ grader = SingleListGrader(
 
 If you give this `cat`, it will tell you that you've got the wrong length, and won't use up an attempt.
 
-Length_error is false by default. If you set length_error to True, then all answers in a tuple of lists (rather than a single answer list) must have the same length.
+`Length_error` is False by default. If you set `length_error` to True, then all answers in a tuple of lists (rather than a single answer list) must have the same length.
+
+
+## Empty Entries
+
+In order to protect students from typos, the grader returns an error if a student's response has an empty entry (or an entry that just contains spaces). If you want students to be able to enter a list with an empty entry, you need to disable this behavior by setting `missing_error=False`.
+
+```pycon
+>>> grader = SingleListGrader(
+...     answers=['cat', 'dog'],
+...     subgrader=StringGrader()
+... )
+>>> try:
+...     grader(None, 'cat, dog,')
+... except MissingInput as error:
+...     print(error)
+List error: Empty entry detected in position 3
+>>> grader = SingleListGrader(
+...     answers=['cat', 'dog'],
+...     subgrader=StringGrader(),
+...     missing_error=False
+... )
+>>> grader(None, 'cat, dog,') == {'grade_decimal': 0.5, 'msg': '', 'ok': 'partial'}
+True
+
+```
 
 
 ## Choosing Delimiters
 
 You can use whatever delimiter you like. The default is a comma (`,`). The following uses a semicolon as a delimiter. We recommend not using multi-character delimiters, but do not disallow it.
 
-```python
+```pycon
 grader = SingleListGrader(
     answers=['cat', 'dog'],
     subgrader=StringGrader(),
@@ -72,7 +105,7 @@ grader = SingleListGrader(
 
 By using different delimiters, it is possible to nest SingleListGraders:
 
-```python
+```pycon
 grader = SingleListGrader(
     answers=[['a', 'b'], ['c', 'd']],
     subgrader=SingleListGrader(
@@ -89,7 +122,7 @@ Here the expected student input is `a, b; c, d`. It will also take `b, a; d, c` 
 
 By default, partial credit is awarded to partially correct answers. Answers that have insufficient items lose points, as do answers that have too many items. To turn off partial credit, set partial_credit to False. It is True by default.
 
-```python
+```pycon
 grader = SingleListGrader(
     answers=['cat', 'dog'],
     subgrader=StringGrader(),
@@ -104,7 +137,7 @@ Now `cat, octopus` will receive a grade of zero.
 
 Messages from the individual items are all concatenated together and presented to the student. It is also possible to have a `wrong_msg` on the `SingleListGrader`, which is presented to the student if the score is zero and there are no other messages, just like on an `ItemGrader`.
 
-```python
+```pycon
 grader = SingleListGrader(
     answers=['cat', 'dog'],
     subgrader=StringGrader(),
@@ -118,11 +151,12 @@ grader = SingleListGrader(
 Here is the full list of options specific to a `SingleListGrader`.
 ```python
 grader = SingleListGrader(
-    answers=list or tuple of lists,
+    answers=list,  # Or tuple of lists
     subgrader=ItemGrader(),
-    partial_credit=bool (default True),
-    ordered=bool (default False),
-    length_error=bool (default False),
-    delimiter=string (default ',')
+    partial_credit=bool,  # default True
+    ordered=bool,  # default False
+    length_error=bool,  # default False
+    missing_error=bool,  # default True
+    delimiter=str,  # default ','
 )
 ```

--- a/docs/grading_lists/single_list_grader.md
+++ b/docs/grading_lists/single_list_grader.md
@@ -63,7 +63,7 @@ grader = SingleListGrader(
 
 If you give this `cat`, it will tell you that you've got the wrong length, and won't use up an attempt.
 
-`Length_error` is False by default. If you set `length_error` to True, then all answers in a tuple of lists (rather than a single answer list) must have the same length.
+By default, `length_error` is set to False. If you set `length_error` to True, then all answers in a tuple of lists (rather than a single answer list) must have the same length.
 
 
 ## Empty Entries

--- a/docs/grading_lists/single_list_grader.md
+++ b/docs/grading_lists/single_list_grader.md
@@ -22,13 +22,20 @@ To receive full points for this problem, a student would enter `cat, dog` or `do
 You can use a tuple of lists to specify multiple lists of answers, just like normal ItemGraders.
 
 ```pycon
-grader = SingleListGrader(
-    answers=(
-        [('cat', 'feline'), 'dog'],
-        ['goat', 'vole'],
-    ),
-    subgrader=StringGrader()
-)
+>>> grader = SingleListGrader(
+...     answers=(
+...         [('cat', 'feline'), 'dog'],
+...         ['goat', 'vole'],
+...     ),
+...     subgrader=StringGrader()
+... )
+>>> grader(None, 'cat, dog') == {'grade_decimal': 1.0, 'msg': '', 'ok': True}
+True
+>>> grader(None, 'dog, feline') == {'grade_decimal': 1.0, 'msg': '', 'ok': True}
+True
+>>> grader(None, 'cat, vole') == {'grade_decimal': 0.5, 'msg': '', 'ok': 'partial'}
+True
+
 ```
 
 Now, `cat, dog` and `goat, vole` will get full grades. But mixes won't: `cat, vole` will score half credit.
@@ -39,11 +46,16 @@ Now, `cat, dog` and `goat, vole` will get full grades. But mixes won't: `cat, vo
 By default a SingleListGrader doesn't care which order the input is given in. If you want the answers and the student input to be compared in order, set `ordered=True`.
 
 ```pycon
-grader = SingleListGrader(
-    answers=['cat', 'dog'],
-    subgrader=StringGrader(),
-    ordered=True
-)
+>>> grader = SingleListGrader(
+...     answers=['cat', 'dog'],
+...     subgrader=StringGrader(),
+...     ordered=True
+... )
+>>> grader(None, 'cat, dog') == {'grade_decimal': 1.0, 'msg': '', 'ok': True}
+True
+>>> grader(None, 'dog, cat') == {'grade_decimal': 0.0, 'msg': '', 'ok': False}
+True
+
 ```
 
 Now `cat, dog` will receive full grades, but `dog, cat` will be marked wrong. Note that `cat` will receive half credit, but `dog` will receive zero, as dog is incorrect in the first position. Ordered is false by default.
@@ -54,11 +66,23 @@ Now `cat, dog` will receive full grades, but `dog, cat` will be marked wrong. No
 If students are asked to enter a list of three items but only enter two, should this use up an attempt, or present an error message? If you want to present an error message, turn on length checking.
 
 ```pycon
-grader = SingleListGrader(
-    answers=['cat', 'dog'],
-    subgrader=StringGrader(),
-    length_error=True
-)
+>>> grader = SingleListGrader(
+...     answers=['cat', 'dog'],
+...     subgrader=StringGrader(),
+... )
+>>> grader(None, 'cat, dog, unicorn') == {'grade_decimal': 0.5, 'msg': '', 'ok': 'partial'}
+True
+>>> grader = SingleListGrader(
+...     answers=['cat', 'dog'],
+...     subgrader=StringGrader(),
+...     length_error=True
+... )
+>>> try:
+...     grader(None, 'cat')
+... except MissingInput as error:
+...     print(error)
+List length error: Expected 2 terms in the list, but received 1. Separate items with character ","
+
 ```
 
 If you give this `cat`, it will tell you that you've got the wrong length, and won't use up an attempt.
@@ -96,23 +120,31 @@ True
 You can use whatever delimiter you like. The default is a comma (`,`). The following uses a semicolon as a delimiter. We recommend not using multi-character delimiters, but do not disallow it.
 
 ```pycon
-grader = SingleListGrader(
-    answers=['cat', 'dog'],
-    subgrader=StringGrader(),
-    delimiter=';'
-)
+>>> grader = SingleListGrader(
+...     answers=['cat', 'dog'],
+...     subgrader=StringGrader(),
+...     delimiter=';'
+... )
+>>> grader(None, 'cat; dog') == {'grade_decimal': 1.0, 'msg': '', 'ok': True}
+True
+
 ```
 
 By using different delimiters, it is possible to nest SingleListGraders:
 
 ```pycon
-grader = SingleListGrader(
-    answers=[['a', 'b'], ['c', 'd']],
-    subgrader=SingleListGrader(
-        subgrader=StringGrader()
-    ),
-    delimiter=';'
-)
+>>> grader = SingleListGrader(
+...     answers=[['a', 'b'], ['c', 'd']],
+...     subgrader=SingleListGrader(
+...         subgrader=StringGrader()
+...     ),
+...     delimiter=';'
+... )
+>>> grader(None, 'd, c; a, b') == {'grade_decimal': 1.0, 'msg': '', 'ok': True}
+True
+>>> grader(None, 'a, c; d, b') == {'grade_decimal': 0.5, 'msg': '', 'ok': 'partial'}
+True
+
 ```
 
 Here the expected student input is `a, b; c, d`. It will also take `b, a; d, c` or `c, d; a, b` due to the unordered nature of both lists. However, `a, c; d, b` is only worth half points.
@@ -123,11 +155,14 @@ Here the expected student input is `a, b; c, d`. It will also take `b, a; d, c` 
 By default, partial credit is awarded to partially correct answers. Answers that have insufficient items lose points, as do answers that have too many items. To turn off partial credit, set partial_credit to False. It is True by default.
 
 ```pycon
-grader = SingleListGrader(
-    answers=['cat', 'dog'],
-    subgrader=StringGrader(),
-    partial_credit=False
-)
+>>> grader = SingleListGrader(
+...     answers=['cat', 'dog'],
+...     subgrader=StringGrader(),
+...     partial_credit=False
+... )
+>>> grader(None, 'cat, octopus') == {'grade_decimal': 0.0, 'msg': '', 'ok': False}
+True
+
 ```
 
 Now `cat, octopus` will receive a grade of zero.
@@ -138,11 +173,14 @@ Now `cat, octopus` will receive a grade of zero.
 Messages from the individual items are all concatenated together and presented to the student. It is also possible to have a `wrong_msg` on the `SingleListGrader`, which is presented to the student if the score is zero and there are no other messages, just like on an `ItemGrader`.
 
 ```pycon
-grader = SingleListGrader(
-    answers=['cat', 'dog'],
-    subgrader=StringGrader(),
-    wrong_msg='Try again!'
-)
+>>> grader = SingleListGrader(
+...     answers=['cat', 'dog'],
+...     subgrader=StringGrader(),
+...     wrong_msg='Try again!'
+... )
+>>> grader(None, 'wolf, feline') == {'grade_decimal': 0.0, 'msg': 'Try again!', 'ok': False}
+True
+
 ```
 
 

--- a/mitxgraders/__init__.py
+++ b/mitxgraders/__init__.py
@@ -27,7 +27,7 @@ from mitxgraders.stringgrader import *
 from mitxgraders.listgrader import *
 from mitxgraders.formulagrader import *
 from mitxgraders.sampling import *
-from mitxgraders.exceptions import ConfigError, StudentFacingError, InvalidInput
+from mitxgraders.exceptions import ConfigError, StudentFacingError, InvalidInput, MissingInput
 from mitxgraders.helpers.calc import *
 from mitxgraders.comparers import *
 

--- a/mitxgraders/listgrader.py
+++ b/mitxgraders/listgrader.py
@@ -698,10 +698,8 @@ class SingleListGrader(ItemGrader):
 
         # Check for empty entries in the list
         if self.config['missing_error']:
-            bad_items = []
-            for idx, item in enumerate(item.strip() for item in student_list):
-                if item == "":
-                    bad_items.append(idx + 1)
+            bad_items = [idx+1 for (idx, item) in enumerate(student_list)
+                         if item.strip() == '']
             if bad_items:
                 if len(bad_items) == 1:
                     msg = 'List error: Empty entry detected in position '

--- a/tests/test_singlelistgrader.py
+++ b/tests/test_singlelistgrader.py
@@ -328,14 +328,38 @@ def test_errors():
     """Tests to ensure that errors are raised appropriately"""
     # All answers have same length in tuple
     with raises(ConfigError, match="All possible list answers must have the same length"):
-        grader = SingleListGrader(
+        SingleListGrader(
             answers=(["1", "2", "3"], ["1", "2"]),
             subgrader=StringGrader()
         )
 
     # Answers must not be empty
     with raises(ConfigError, match="Cannot have an empty list of answers"):
-        grader = SingleListGrader(
+        SingleListGrader(
             answers=([], []),
             subgrader=StringGrader()
         )
+
+    # Empty entries raises an error
+    grader = SingleListGrader(
+        answers=['1', '2', '3'],
+        subgrader=StringGrader()
+    )
+    with raises(MissingInput, match="List error: Empty entry detected in position 1"):
+        grader(None, ',1,2,3')
+    with raises(MissingInput, match="List error: Empty entry detected in position 4"):
+        grader(None, '1,2,3,')
+    with raises(MissingInput, match="List error: Empty entry detected in position 2"):
+        grader(None, '1,,2,3')
+    with raises(MissingInput, match="List error: Empty entries detected in positions 1, 3"):
+        grader(None, ',1,,2,3')
+
+    grader = SingleListGrader(
+        answers=['1', '2', '3'],
+        subgrader=StringGrader(),
+        missing_error=False
+    )
+    grader(None, ',1,2,3')['grade_decimal'] = 0.75
+    grader(None, '1,2,3,')['grade_decimal'] = 0.75
+    grader(None, '1,,2,3')['grade_decimal'] = 0.75
+    grader(None, ',1,2,3,')['grade_decimal'] = 0.6


### PR DESCRIPTION
Adds an option to SingleListGrader to detect and present an error if there are empty entries in a list, turned on by default.

Includes tests and documentation (I started converting the examples to doctests).

Resolves #167.