### PR TITLE
Adding the ApplyFunctionComparer comparer

### DIFF
--- a/mitxgraders/comparers/__init__.py
+++ b/mitxgraders/comparers/__init__.py
@@ -1,24 +1,29 @@
 from __future__ import print_function, division, absolute_import
 
 from mitxgraders.comparers.comparers import (
+    EqualityComparer,
     equality_comparer,
+    ApplyFunctionComparer,
     congruence_comparer,
     eigenvector_comparer,
     between_comparer,
     vector_span_comparer,
     vector_phase_comparer
 )
-from mitxgraders.comparers.baseclasses import CorrelatedComparer
+from mitxgraders.comparers.baseclasses import Comparer, CorrelatedComparer
 
 from mitxgraders.comparers.linear_comparer import LinearComparer
 
 __all__ = [
+    'EqualityComparer',
     'equality_comparer',
+    'ApplyFunctionComparer',
     'congruence_comparer',
     'eigenvector_comparer',
     'between_comparer',
     'vector_span_comparer',
     'vector_phase_comparer',
+    'Comparer',
     'CorrelatedComparer',
     'LinearComparer'
 ]

--- a/mitxgraders/comparers/__init__.py
+++ b/mitxgraders/comparers/__init__.py
@@ -3,7 +3,6 @@ from __future__ import print_function, division, absolute_import
 from mitxgraders.comparers.comparers import (
     EqualityComparer,
     equality_comparer,
-    ApplyFunctionComparer,
     congruence_comparer,
     eigenvector_comparer,
     between_comparer,
@@ -17,7 +16,6 @@ from mitxgraders.comparers.linear_comparer import LinearComparer
 __all__ = [
     'EqualityComparer',
     'equality_comparer',
-    'ApplyFunctionComparer',
     'congruence_comparer',
     'eigenvector_comparer',
     'between_comparer',

--- a/mitxgraders/comparers/baseclasses.py
+++ b/mitxgraders/comparers/baseclasses.py
@@ -8,7 +8,33 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 import abc
 from mitxgraders.baseclasses import ObjectWithSchema
 
-class CorrelatedComparer(ObjectWithSchema):
+class Comparer(ObjectWithSchema):
+    """
+    Comparers are callable objects used as comparer functions in FormulaGrader problems.
+    Unlike standard comparer functions, Comparers can be passed options at instantiation.
+
+    This class is abstract. Comparers should inherit from it.
+    """
+
+    # This is an abstract base class
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def __call__(self, comparer_params_eval, student_eval, utils):
+        """
+        Compares student input evalution with expected evaluation.
+
+        Arguments:
+            `comparer_params_eval`: The `comparer_params` list, numerically evaluated
+                according to variable and function sampling.
+            `student_eval`: The student's input, numerically evaluated according to
+                variable and function sampling.
+            `utils`: a convenience object, same as for simple comparers.
+        Returns:
+            bool or results dict
+        """
+
+class CorrelatedComparer(Comparer):
     """
     CorrelatedComparer are callable objects used as comparer functions
     in FormulaGrader problems. Unlike standard comparer functions, CorrelatedComparer

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -587,7 +587,7 @@ def test_fg_debug_log():
     "==========================================<br/>\n"
     "Comparison Data for All 2 Samples<br/>\n"
     "==========================================<br/>\n"
-    "Comparer Function: <function equality_comparer at 0x...><br/>\n"
+    "Comparer Function: EqualityComparer({{}})<br/>\n"
     "Comparison Results:<br/>\n"
     "[{{{u}'grade_decimal': 1.0, {u}'msg': {u}'', {u}'ok': True}},<br/>\n"
     " {{{u}'grade_decimal': 1.0, {u}'msg': {u}'', {u}'ok': True}}]<br/>\n"

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -587,7 +587,7 @@ def test_fg_debug_log():
     "==========================================<br/>\n"
     "Comparison Data for All 2 Samples<br/>\n"
     "==========================================<br/>\n"
-    "Comparer Function: EqualityComparer({{}})<br/>\n"
+    "Comparer Function: EqualityComparer({{{u}'transform': None}})<br/>\n"
     "Comparison Results:<br/>\n"
     "[{{{u}'grade_decimal': 1.0, {u}'msg': {u}'', {u}'ok': True}},<br/>\n"
     " {{{u}'grade_decimal': 1.0, {u}'msg': {u}'', {u}'ok': True}}]<br/>\n"


### PR DESCRIPTION
Creates a comparer that applies a python function to the expected result and student input before performing the comparison. I thought about doing this based on string references to functions the grader already knows about, before realizing that comparers don't have access to the function listing etc.

In order to implement this, I created a new base class `Comparer`, of which `CorrelatedComparer` is a subclass. I also made an `EqualityComparer` class from which `equality_comparer` derives.

Question: Do you think that I should just merge `ApplyFunctionComparer` into `EqualityComparer`? They're almost copies of each other.

Resolves #192.