### PR TITLE
Remove inplace ops

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+try:
+    # Prior to version 1.13, numpy added an extra space before floats when printing arrays
+    # We use 1.6 for Python 2 and 1.16 for Python 3, so the printing difference
+    # causes problems for doctests.
+    #
+    # Setting the printer to legacy 1.13 combined with the doctest directive
+    # NORMALIZE_WHITESPACE is fixes the issue.
+    np.set_printoptions(legacy='1.13')
+    body = "# Setting numpy to print in legacy mode"
+    msg = "{header}\n{body}\n{footer}".format(header='#'*40, footer='#'*40, body=body)
+    print(msg)
+except TypeError:
+    pass

--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,7 @@ try:
     # causes problems for doctests.
     #
     # Setting the printer to legacy 1.13 combined with the doctest directive
-    # NORMALIZE_WHITESPACE is fixes the issue.
+    # NORMALIZE_WHITESPACE fixes the issue.
     np.set_printoptions(legacy='1.13')
     body = "# Setting numpy to print in legacy mode"
     msg = "{header}\n{body}\n{footer}".format(header='#'*40, footer='#'*40, body=body)

--- a/docs/grading_math/matrix_grader/matrix_grader.md
+++ b/docs/grading_math/matrix_grader/matrix_grader.md
@@ -164,9 +164,11 @@ Vectors are distinct from single-row matrices and single-column matrices, and ca
 >>> vec = MathArray([1, 2, 3])
 >>> row = MathArray([[1, 2, 3]])
 >>> col = MathArray([[1], [2], [3]])
->>> vec + row # raises error
-Traceback (most recent call last):
-MathArrayShapeError: Cannot add/subtract a vector of length 3 with a matrix of shape (rows: 1, cols: 3).
+>>> try:
+...     vec + row # raises error
+... except StudentFacingError as error:
+...     print(error)
+Cannot add/subtract a vector of length 3 with a matrix of shape (rows: 1, cols: 3).
 
 >>> A = MathArray([[1, 2, 3], [4, 5, 6]])
 >>> A * vec # matrix * vector
@@ -200,20 +202,26 @@ Some sample error messages:
 | `'A^2'`   | No  |  Cannot raise a non-square matrix to powers.    |
 | `'B^2'`   | Yes |  n/a    |
 
-<!-- Test the messages -->
+<!-- Test the messages (internal verification, not shown in docs) -->
 <!-- ```pycon
->>> A + B
-Traceback (most recent call last):
-MathArrayShapeError: Cannot add/subtract a matrix of shape (rows: 3, cols: 2) with a matrix of shape (rows: 2, cols: 2).
+>>> from mitxgraders.helpers.calc.exceptions import MathArrayShapeError
+>>> try:
+...     A + B
+... except MathArrayShapeError as error:
+...     print(error)
+Cannot add/subtract a matrix of shape (rows: 3, cols: 2) with a matrix of shape (rows: 2, cols: 2).
 
+>>> try:
+...     v*A
+... except MathArrayShapeError as error:
+...     print(error)
+Cannot multiply a vector of length 2 with a matrix of shape (rows: 3, cols: 2).
 
->>> v*A
-Traceback (most recent call last):
-MathArrayShapeError: Cannot multiply a vector of length 2 with a matrix of shape (rows: 3, cols: 2).
-
->>> A**2
-Traceback (most recent call last):
-MathArrayShapeError: Cannot raise a non-square matrix to powers.
+>>> try:
+...     A**2
+... except MathArrayShapeError as error:
+...     print(error)
+Cannot raise a non-square matrix to powers.
 
 ``` -->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -131,10 +131,12 @@ The options passed to a grading class undergo extensive validation and graders w
 A few error messages serve only as warnings. For example, if you attempt to configure a `FormulaGrader` with `pi` as a variable, you will receive a warning:
 
 ```pycon
->>> from mitxgraders import FormulaGrader
->>> grader = FormulaGrader(variables=['pi'])
-Traceback (most recent call last):
-ConfigError: Warning: 'variables' contains entries 'pi' which will override default values. If you intend to override defaults, you may suppress this warning by adding 'suppress_warnings=True' to the grader configuration.
+>>> from mitxgraders import *
+>>> try:
+...     grader = FormulaGrader(variables=['pi'])
+... except ConfigError as error:
+...     print(error)
+Warning: 'variables' contains entries 'pi' which will override default values. If you intend to override defaults, you may suppress this warning by adding 'suppress_warnings=True' to the grader configuration.
 
 ```
 

--- a/mitxgraders/comparers/comparers.py
+++ b/mitxgraders/comparers/comparers.py
@@ -93,9 +93,11 @@ def between_comparer(comparer_params_eval, student_eval, utils):
     True
 
     Input must be real:
-    >>> grader(None, '5e8+2e6*i')['ok']
-    Traceback (most recent call last):
-    InputTypeError: Input must be real.
+    >>> try:
+    ...     grader(None, '5e8+2e6*i')['ok']
+    ... except InputTypeError as error:
+    ...     print(error)
+    Input must be real.
     """
     start, stop = comparer_params_eval
 
@@ -232,9 +234,11 @@ def vector_span_comparer(comparer_params_eval, student_eval, utils):
     True
 
     Input shape is validated:
-    >>> grader(None, '5')
-    Traceback (most recent call last):
-    InputTypeError: Expected answer to be a vector, but input is a scalar
+    >>> try:
+    ...     grader(None, '5')
+    ... except InputTypeError as error:
+    ...     print(error)
+    Expected answer to be a vector, but input is a scalar
 
     Multiple vectors can be provided:
     >>> grader = MatrixGrader(
@@ -261,9 +265,11 @@ def vector_span_comparer(comparer_params_eval, student_eval, utils):
     ...         'comparer': vector_span_comparer
     ...     },
     ... )
-    >>> grader(None, '[1, 2, 3]')               # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-    StudentFacingError: Problem Configuration Error: ...to equal-length vectors
+    >>> try:
+    ...     grader(None, '[1, 2, 3]')               # doctest: +ELLIPSIS
+    ... except StudentFacingError as error:
+    ...     print(error)
+    Problem Configuration Error: ...to equal-length vectors
     """
 
     # Validate the comparer params
@@ -337,9 +343,11 @@ def vector_phase_comparer(comparer_params_eval, student_eval, utils):
     ...         'comparer': vector_phase_comparer
     ...     },
     ... )
-    >>> grader(None, '[1, 2, 3]')               # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-    StudentFacingError: Problem Configuration Error: ...to a single vector.
+    >>> try:
+    ...     grader(None, '[1, 2, 3]')               # doctest: +ELLIPSIS
+    ... except StudentFacingError as error:
+    ...     print(error)
+    Problem Configuration Error: ...to a single vector.
     """
     # Validate that author comparer_params evaluate to a single vector
     if not len(comparer_params_eval) == 1 and is_vector(comparer_params_eval[0]):

--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -72,13 +72,14 @@ def validate_forbidden_strings_not_used(expr, forbidden_strings, forbidden_msg):
     True
 
     Fails validation if any forbidden string is used:
-    >>> validate_forbidden_strings_not_used(
-    ... 'sin(x+x)',
-    ... ['*x', '+ x', '- x'],
-    ... 'A forbidden string was used!'
-    ... )
-    Traceback (most recent call last):
-    InvalidInput: A forbidden string was used!
+    >>> try:
+    ...     validate_forbidden_strings_not_used(
+    ...         'sin(x+x)',
+    ...         ['*x', '+ x', '- x'],
+    ...         'A forbidden string was used!')
+    ... except InvalidInput as error:
+    ...     print(error)
+    A forbidden string was used!
     """
     stripped_expr = expr.replace(' ', '')
     for forbidden in forbidden_strings:
@@ -101,14 +102,15 @@ def validate_only_permitted_functions_used(used_funcs, permitted_functions):
     ... set(['f', 'g', 'sin', 'cos'])
     ... )
     True
-    >>> validate_only_permitted_functions_used(
-    ... set(['f', 'Sin', 'h']),
-    ... set(['f', 'g', 'sin', 'cos'])
-    ... )
-    Traceback (most recent call last):
-    InvalidInput: Invalid Input: function(s) 'h', 'Sin' not permitted in answer
+    >>> try:
+    ...     validate_only_permitted_functions_used(
+    ...         set(['f', 'Sin', 'h']),
+    ...         set(['f', 'g', 'sin', 'cos']))
+    ... except InvalidInput as error:
+    ...     print(error)
+    Invalid Input: function(s) 'Sin', 'h' not permitted in answer
     """
-    used_not_permitted = [f for f in used_funcs if f not in permitted_functions]
+    used_not_permitted = sorted([f for f in used_funcs if f not in permitted_functions])
     if used_not_permitted:
         func_names = ", ".join(["'{f}'".format(f=f) for f in used_not_permitted])
         message = "Invalid Input: function(s) {} not permitted in answer".format(func_names)
@@ -167,14 +169,15 @@ def get_permitted_functions(default_funcs, whitelist, blacklist, always_allowed)
     Blacklist and whitelist cannot be simultaneously used:
     >>> default_funcs = {'sin': None, 'cos': None, 'tan': None}
     >>> always_allowed = {'f1': None, 'f2': None}
-    >>> get_permitted_functions(
-    ...     default_funcs,
-    ...     ['sin'],
-    ...     ['cos'],
-    ...     always_allowed
-    ... )
-    Traceback (most recent call last):
-    ValueError: whitelist and blacklist cannot both be non-empty
+    >>> try:
+    ...     get_permitted_functions(
+    ...         default_funcs,
+    ...         ['sin'],
+    ...         ['cos'],
+    ...         always_allowed)
+    ... except ValueError as error:
+    ...     print(error)
+    whitelist and blacklist cannot both be non-empty
     """
     # should never trigger except in doctest above,
     # Grader's config validation should raise an error first
@@ -200,12 +203,13 @@ def validate_required_functions_used(used_funcs, required_funcs):
     ... ['cos', 'f']
     ... )
     True
-    >>> validate_required_functions_used(
-    ... ['sin', 'cos', 'F', 'g'],
-    ... ['cos', 'f']
-    ... )
-    Traceback (most recent call last):
-    InvalidInput: Invalid Input: Answer must contain the function f
+    >>> try:
+    ...     validate_required_functions_used(
+    ...     ['sin', 'cos', 'F', 'g'],
+    ...     ['cos', 'f'])
+    ... except InvalidInput as error:
+    ...     print(error)
+    Invalid Input: Answer must contain the function f
     """
     for func in required_funcs:
         if func not in used_funcs:
@@ -262,21 +266,25 @@ def validate_no_collisions(config, keys):
 
     Duplicate entries raise a ConfigError:
     >>> keys = ['variables', 'user_constants', 'numbered_vars']
-    >>> validate_no_collisions({
-    ...     'variables':['a', 'b', 'c', 'x', 'y'],
-    ...     'user_constants':{'x': 5, 'y': 10},
-    ...     'numbered_vars':['phi', 'psi']
-    ... }, keys)
-    Traceback (most recent call last):
-    ConfigError: 'user_constants' and 'variables' contain duplicate entries: ['x', 'y']
+    >>> try:
+    ...     validate_no_collisions({
+    ...         'variables':['a', 'b', 'c', 'x', 'y'],
+    ...         'user_constants':{'x': 5, 'y': 10},
+    ...         'numbered_vars':['phi', 'psi']
+    ...         }, keys)
+    ... except ConfigError as error:
+    ...     print(error)
+    'user_constants' and 'variables' contain duplicate entries: ['x', 'y']
 
-    >>> validate_no_collisions({
-    ...     'variables':['a', 'psi', 'phi', 'X', 'Y'],
-    ...     'user_constants':{'x': 5, 'y': 10},
-    ...     'numbered_vars':['phi', 'psi']
-    ... }, keys)
-    Traceback (most recent call last):
-    ConfigError: 'numbered_vars' and 'variables' contain duplicate entries: ['phi', 'psi']
+    >>> try:
+    ...     validate_no_collisions({
+    ...         'variables':['a', 'psi', 'phi', 'X', 'Y'],
+    ...         'user_constants':{'x': 5, 'y': 10},
+    ...         'numbered_vars':['phi', 'psi']
+    ...         }, keys)
+    ... except ConfigError as error:
+    ...     print(error)
+    'numbered_vars' and 'variables' contain duplicate entries: ['phi', 'psi']
 
     Without duplicates, return True
     >>> validate_no_collisions({
@@ -308,13 +316,12 @@ def warn_if_override(config, key, defaults):
     =====
 
     >>> config = {'vars': ['a', 'b', 'cat', 'psi', 'pi']}
-    >>> warn_if_override(
-    ... config,
-    ... 'vars',
-    ... {'cat': 1, 'pi': 2}
-    ... ) # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-    ConfigError: Warning: 'vars' contains entries 'cat', 'pi' ...
+    >>> defaults = {'cat': 1, 'pi': 2}
+    >>> try:
+    ...     warn_if_override(config, 'vars', defaults) # doctest: +ELLIPSIS
+    ... except ConfigError as error:
+    ...     print(error)
+    Warning: 'vars' contains entries 'cat', 'pi' ...
 
     >>> config = {'vars': ['a', 'b', 'cat', 'psi', 'pi'], 'suppress_warnings': True}
     >>> warn_if_override(

--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -709,7 +709,7 @@ class FormulaGrader(ItemGrader):
                                           self.suffixes,
                                           self.constants)
 
-        func_samples = gen_symbols_samples(self.random_funcs.keys(),
+        func_samples = gen_symbols_samples(list(self.random_funcs.keys()),
                                            self.config['samples'],
                                            self.random_funcs,
                                            self.functions,

--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -755,7 +755,7 @@ class MathExpression(object):
         """
         result = float(parse_result[0])
         if len(parse_result) == 2:
-            result *= suffixes[parse_result[1]]
+            result = result * suffixes[parse_result[1]]
         return result
 
     @staticmethod
@@ -1086,14 +1086,14 @@ class MathExpression(object):
             op = data.pop(0)
             value = data.pop(0)
             if op == '/':
-                result /= value
+                result = result/value
             elif op == '*':
                 if is_vector(value):
                     if double_vector_mult_has_occured:
                         raise triple_vector_mult_error
                     elif is_vector(result):
                         double_vector_mult_has_occured = True
-                result *= value
+                result = result*value
             else:
                 raise CalcError("Unexpected symbol {} in eval_product".format(op))
 
@@ -1132,9 +1132,9 @@ class MathExpression(object):
             op = data.pop(0)
             num = data.pop(0)
             if op == '+':
-                result += num
+                result = result + num
             elif op == '-':
-                result -= num
+                result = result - num
             else:
                 raise CalcError("Unexpected symbol {} in eval_sum".format(op))
         return result

--- a/mitxgraders/helpers/calc/math_array.py
+++ b/mitxgraders/helpers/calc/math_array.py
@@ -16,8 +16,8 @@ def is_number_zero(value):
     """
     Tests whether a value is the scalar number 0.
 
-    >>> map(is_number_zero, [0, 0.0, 0j])
-    [True, True, True]
+    >>> is_number_zero(0), is_number_zero(0.0), is_number_zero(0)
+    (True, True, True)
     >>> is_number_zero(np.matrix([0, 0, 0]))
     False
     """
@@ -434,10 +434,10 @@ def identity(n):
 
     Usage:
 
-    >>> identity(2)
+    >>> identity(2)                             # doctest: +NORMALIZE_WHITESPACE
     MathArray([[ 1.,  0.],
            [ 0.,  1.]])
-    >>> identity(3)
+    >>> identity(3)                             # doctest: +NORMALIZE_WHITESPACE
     MathArray([[ 1.,  0.,  0.],
            [ 0.,  1.,  0.],
            [ 0.,  0.,  1.]])

--- a/mitxgraders/helpers/calc/math_array.py
+++ b/mitxgraders/helpers/calc/math_array.py
@@ -16,7 +16,7 @@ def is_number_zero(value):
     """
     Tests whether a value is the scalar number 0.
 
-    >>> is_number_zero(0), is_number_zero(0.0), is_number_zero(0)
+    >>> is_number_zero(0), is_number_zero(0.0), is_number_zero(0j)
     (True, True, True)
     >>> is_number_zero(np.matrix([0, 0, 0]))
     False

--- a/mitxgraders/helpers/calc/math_array.py
+++ b/mitxgraders/helpers/calc/math_array.py
@@ -385,7 +385,8 @@ class MathArray(np.ndarray):
         raise TypeError("Cannot raise {type} to power of {self.shape_name}."
                         .format(type=type(other), self=self))
 
-    # in-place operations
+    # fake in-place operations
+    # they enable in-place syntax but return new objects
 
     def __iadd__(self, other):
         return self.__add__(other)

--- a/mitxgraders/helpers/calc/mathfuncs.py
+++ b/mitxgraders/helpers/calc/mathfuncs.py
@@ -128,7 +128,7 @@ def real(z):
     >>> isinstance(real(2+3j), float)
     True
 
-    Can be used with arrays, too:
+    Can be used with arrays, too:               # doctest: +NORMALIZE_WHITESPACE
     >>> real(np.array([1+10j, 2+20j, 3+30j]))
     array([ 1.,  2.,  3.])
     """
@@ -190,9 +190,11 @@ def factorial(z):
     True
 
     Throws errors at poles:
-    >>> factorial(-2)                           # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-    FunctionEvalError: Error evaluating factorial() or fact() in input...
+    >>> try:                                                # doctest: +ELLIPSIS
+    ...     factorial(-2)
+    ... except FunctionEvalError as error:
+    ...     print(error)
+    Error evaluating factorial() or fact() in input...
     """
 
     try:
@@ -442,18 +444,20 @@ def is_nearly_zero(x, tolerance, reference=None):
     False
 
     Works for arrays, too:
-    >>> x = np.array([[1, 1], [1, -1]])/10
-    >>> round(np.linalg.norm(x), 6)
-    0.2
-    >>> is_nearly_zero(x, '5%', reference=10)
+    >>> x = np.array([[1, 1], [0, -1]])
+    >>> np.linalg.norm(x)                                   # doctest: +ELLIPSIS
+    1.732050...
+    >>> is_nearly_zero(x, '18%', reference=10)
     True
-    >>> is_nearly_zero(x, '1.5%', reference=10)
+    >>> is_nearly_zero(x, '17%', reference=10)
     False
 
     A ValueError is raised when percentage tolerance is used without reference:
-    >>> is_nearly_zero(0.4, '3%')
-    Traceback (most recent call last):
-    ValueError: When tolerance is a percentage, reference must not be None.
+    >>> try:
+    ...     is_nearly_zero(0.4, '3%')
+    ... except ValueError as error:
+    ...     print(error)
+    When tolerance is a percentage, reference must not be None.
     """
     # When used within graders, tolerance has already been
     # validated as a Number or PercentageString

--- a/mitxgraders/helpers/calc/specify_domain.py
+++ b/mitxgraders/helpers/calc/specify_domain.py
@@ -49,12 +49,16 @@ def number_validator(obj):
     True
 
     Provides a useful error message:
-    >>> number_validator(MathArray([1, 2, 3]))
-    Traceback (most recent call last):
-    Invalid: received a vector of length 3, expected a scalar
-    >>> number_validator([1, 2, 3])
-    Traceback (most recent call last):
-    Invalid: received a list, expected a scalar
+    >>> try:
+    ...     number_validator(MathArray([1, 2, 3]))
+    ... except Invalid as error:
+    ...     print(error)
+    received a vector of length 3, expected a scalar
+    >>> try:
+    ...     number_validator([1, 2, 3])
+    ... except Invalid as error:
+    ...     print(error)
+    received a list, expected a scalar
 
     """
     if isinstance(obj, Number):
@@ -82,33 +86,41 @@ def make_shape_validator(shape):
     MathArray([1, 2, 3, 4])
 
     Provides useful error messages if obj is a number or MathArray:
-    >>> validate_vec4(MathArray([[1, 2, 3], [4, 5, 6]]))
-    Traceback (most recent call last):
-    Invalid: received a matrix of shape (rows: 2, cols: 3), expected a vector of length 4
-    >>> validate_vec4(5)
-    Traceback (most recent call last):
-    Invalid: received a scalar, expected a vector of length 4
+    >>> try:
+    ...     validate_vec4(MathArray([[1, 2, 3], [4, 5, 6]]))
+    ... except Invalid as error:
+    ...     print(error)
+    received a matrix of shape (rows: 2, cols: 3), expected a vector of length 4
+    >>> try:
+    ...     validate_vec4(5)
+    ... except Invalid as error:
+    ...     print(error)
+    received a scalar, expected a vector of length 4
 
     Fallback error message shows Python type:
-    >>> validate_vec4({})
-    Traceback (most recent call last):
-    Invalid: received a dict, expected a vector of length 4
+    >>> try:
+    ...     validate_vec4({})
+    ... except Invalid as error:
+    ...     print(error)
+    received a dict, expected a vector of length 4
 
     Instead of specifying a tuple shape, you can specify 'square' to demand
     square matrices of any dimension.
     >>> validate_square = make_shape_validator('square')
     >>> square2 = MathArray([[1, 2], [3, 4]])
     >>> square3 = MathArray([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    >>> validate_square(square2)
+    >>> validate_square(square2)                # doctest: +NORMALIZE_WHITESPACE
     MathArray([[1, 2],
            [3, 4]])
-    >>> validate_square(square3)
+    >>> validate_square(square3)                # doctest: +NORMALIZE_WHITESPACE
     MathArray([[1, 2, 3],
            [4, 5, 6],
            [7, 8, 9]])
-    >>> validate_square(MathArray([1, 2, 3, 4]))
-    Traceback (most recent call last):
-    Invalid: received a vector of length 4, expected a square matrix
+    >>> try:
+    ...     validate_square(MathArray([1, 2, 3, 4]))
+    ... except Invalid as error:
+    ...     print(error)
+    received a vector of length 4, expected a square matrix
     """
     def shape_validator(obj):
         if isinstance(obj, MathArray):
@@ -167,14 +179,18 @@ class SpecifyDomain(ObjectWithSchema):
     If inputs are bad, student-facing ArgumentShapeErrors are thrown:
     >>> a = MathArray([2, -1, 3])
     >>> b = MathArray([-1, 4])
-    >>> cross(a, b)                                 # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-    ArgumentShapeError: There was an error evaluating function cross(...)
+    >>> try:
+    ...     cross(a, b)
+    ... except ArgumentShapeError as error:
+    ...     print(error)
+    There was an error evaluating function cross(...)
     1st input is ok: received a vector of length 3 as expected
     2nd input has an error: received a vector of length 2, expected a vector of length 3
-    >>> cross(a)
-    Traceback (most recent call last):
-    ArgumentError: Wrong number of arguments passed to cross(...): Expected 2 inputs, but received 1.
+    >>> try:
+    ...     cross(a)
+    ... except ArgumentError as error:
+    ...     print(error)
+    Wrong number of arguments passed to cross(...): Expected 2 inputs, but received 1.
 
     To specify that an input should be a an array of specific size, use a list or tuple
     for that shape value. Below, [3, 2] specifies a 3 by 2 matrix (the tuple
@@ -184,9 +200,11 @@ class SpecifyDomain(ObjectWithSchema):
     ... def f(x, y, z):
     ...     pass # implement complicated stuff here
     >>> square_mat = MathArray([[1, 2], [3, 4]])
-    >>> f(1, 2, 3, square_mat)                                      # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-    ArgumentShapeError: There was an error evaluating function f(...)
+    >>> try:
+    ...     f(1, 2, 3, square_mat)
+    ... except ArgumentShapeError as error:
+    ...     print(error)
+    There was an error evaluating function f(...)
     1st input is ok: received a scalar as expected
     2nd input has an error: received a scalar, expected a matrix of shape (rows: 3, cols: 2)
     3rd input has an error: received a scalar, expected a vector of length 2

--- a/mitxgraders/helpers/get_number_of_args.py
+++ b/mitxgraders/helpers/get_number_of_args.py
@@ -86,6 +86,11 @@ def get_number_of_args_py3(callable_obj):
         - based on inspect.signature
         - in Python 2, use getargspec-based get_number_of_args_py3 instead
     """
+    if hasattr(callable_obj, "nin"):
+        # Matches RandomFunction or numpy ufunc
+        # Sadly, even Py3's inspect.signature can't handle numpy ufunc...
+        return callable_obj.nin
+
     params = inspect.signature(callable_obj).parameters
     empty = inspect.Parameter.empty
     return sum([params[key].default == empty for key in params])

--- a/mitxgraders/helpers/get_number_of_args.py
+++ b/mitxgraders/helpers/get_number_of_args.py
@@ -1,0 +1,146 @@
+import inspect
+import six
+
+def get_builtin_positional_args(obj):
+    """
+    Get the number of position arguments on a built-in function by inspecting
+    its docstring. (Built-in functions cannot be inspected by inspect.inspect.getargspec.)
+
+    NOTE:
+        - works in Python 3, but intended for Python 2
+
+    >>> pow.__doc__     # doctest: +ELLIPSIS
+    'pow(x, y[, z]) -> number...
+    >>> get_builtin_positional_args(pow)
+    2
+    """
+    # Built-in functions cannot be inspected by
+    # inspect.inspect.getargspec. We have to try and parse
+    # the __doc__ attribute of the function.
+    docstr = obj.__doc__
+    if docstr:
+        items = docstr.split('\n')
+        if items:
+            func_descr = items[0]
+            s = func_descr.replace(obj.__name__, '')
+            idx1 = s.find('(')
+            idx_default = s.find('[')
+            idx2 = s.find(')') if idx_default == -1 else idx_default
+            if idx1 != -1 and idx2 != -1 and (idx2 > idx1+1):
+                argstring = s[idx1+1:idx2]
+                # This gets the argument string
+                # Count the number of commas!
+                return argstring.count(",") + 1
+    return 0  # pragma: no cover
+
+def get_number_of_args_py2(callable_obj):
+    """
+    Get number of positional arguments of function or callable object.
+
+    NOTES:
+        - Seems to work in Python 3, but is based on inspect.getargspec which
+          raises a DeprecationWarning in Python 3.
+        - in Python 3, use the much simpler signature-based
+          get_number_of_args_py3 funciton instead.
+    """
+
+    if inspect.isbuiltin(callable_obj):
+        # Built-in function
+        func = callable_obj
+        return get_builtin_positional_args(func)
+    elif hasattr(callable_obj, "nin"):
+        # Matches RandomFunction or numpy ufunc
+        return callable_obj.nin
+    else:
+        if inspect.isfunction(callable_obj) or inspect.ismethod(callable_obj):
+            # Assume object is a function
+            func = callable_obj
+            # see https://docs.python.org/2/library/inspect.html#inspect.inspect.getargspec
+            # defaults might be None, or something weird for Mock functions
+            args, _, _, defaults = inspect.getargspec(func)
+        else:
+            # Callable object
+            func = callable_obj.__call__
+            args, _, _, defaults = inspect.getargspec(func)
+
+    try:
+        num_args = len(args) - len(defaults)
+    except TypeError:
+        num_args = len(args)
+
+    # If func is a bound method, remove one argument
+    # (in Python 2.7, unbound methods have __self__ = None)
+    try:
+        if func.__self__ is not None:
+            num_args += -1
+    except AttributeError:
+        pass
+
+    return num_args
+
+def get_number_of_args_py3(callable_obj):
+    """
+    Get number of positional arguments of function or callable object.
+
+    NOTES:
+        - based on inspect.signature
+        - in Python 2, use getargspec-based get_number_of_args_py3 instead
+    """
+    params = inspect.signature(callable_obj).parameters
+    empty = inspect.Parameter.empty
+    return sum([params[key].default == empty for key in params])
+
+def get_number_of_args(callable_obj):
+    """
+    Get number of positional arguments of function or callable object.
+
+    Examples
+    ========
+
+    Works for simple functions:
+    >>> def f(x, y):
+    ...     return x + y
+    >>> get_number_of_args(f)
+    2
+
+    Positional arguments only:
+    >>> def f(x, y, z=5):
+    ...     return x + y
+    >>> get_number_of_args(f)
+    2
+
+    Works with bound and unbound object methods
+    >>> class Foo:
+    ...     def do_stuff(self, x, y, z):
+    ...         return x*y*z
+    >>> get_number_of_args(Foo.do_stuff) # unbound, is NOT automatically passed self as argument
+    4
+    >>> foo = Foo()
+    >>> get_number_of_args(foo.do_stuff) # bound, is automatically passed self as argument
+    3
+
+    Works for bound and unbound callable objects
+    >>> class Bar:
+    ...     def __call__(self, x, y):
+    ...         return x + y
+    >>> get_number_of_args(Bar) # unbound, is NOT automatically passed self as argument
+    3
+    >>> bar = Bar()
+    >>> get_number_of_args(bar) # bound, is automatically passed self as argument
+    2
+
+    Works on built-in functions (assuming their docstring is correct)
+    >>> import math
+    >>> get_number_of_args(math.sin)
+    1
+
+    Works on numpy ufuncs
+    >>> import numpy as np
+    >>> get_number_of_args(np.sin)
+    1
+
+    Works on RandomFunctions (tested in unit tests due to circular imports)
+    """
+    if six.PY2:
+        return get_number_of_args_py2(callable_obj)
+    return get_number_of_args_py3(callable_obj)

--- a/mitxgraders/helpers/get_number_of_args.py
+++ b/mitxgraders/helpers/get_number_of_args.py
@@ -46,7 +46,7 @@ def get_number_of_args_py2(callable_obj):
 
     Usage
     =====
-    See documetnation for get_number_of_args.
+    See documentation for get_number_of_args.
 
     Note, however, that this function cannot handle class constructors:
 
@@ -105,7 +105,7 @@ def get_number_of_args_py3(callable_obj):
 
     NOTES:
         - based on inspect.signature
-        - in Python 2, use getargspec-based get_number_of_args_py3 instead
+        - in Python 2, use getargspec-based get_number_of_args_py2 instead
     """
     if hasattr(callable_obj, "nin"):
         # Matches RandomFunction or numpy ufunc

--- a/mitxgraders/helpers/validatorfuncs.py
+++ b/mitxgraders/helpers/validatorfuncs.py
@@ -232,13 +232,16 @@ def is_shape_specification(min_dim=1, max_dim=None):
 
     Valid inputs are standardized to tuples:
     >>> vec_or_mat = Schema(is_shape_specification(min_dim=1, max_dim=2))
-    >>> map(vec_or_mat, [3, (3,), [3], (4, 2), [4, 2] ])
+    >>> valid_examples = [3, (3,), [3], (4, 2), [4, 2] ]
+    >>> [vec_or_mat(item) for item in valid_examples]
     [(3,), (3,), (3,), (4, 2), (4, 2)]
 
     Invalid inputs raise a useful error:
-    >>> vec_or_mat(0)                               # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-    MultipleInvalid: expected shape specification to be a positive integer,...
+    >>> try:                                                # doctest: +ELLIPSIS
+    ...     vec_or_mat(0)
+    ... except Invalid as error:
+    ...     print(error)
+    expected shape specification to be a positive integer,...
     """
 
     msg = ('expected shape specification to be a positive integer, or a '

--- a/mitxgraders/helpers/validatorfuncs.py
+++ b/mitxgraders/helpers/validatorfuncs.py
@@ -193,10 +193,10 @@ def is_callable_with_args(num_args):
     >>> is_callable_with_args(1)(foo) == foo
     True
     >>> try:                                                # doctest: +ELLIPSIS
-    ...     is_callable_with_args(1)(Foo)
+    ...     is_callable_with_args(2)(foo)
     ... except Invalid as error:
     ...     print(error)
-    Expected function... to have 1 arguments, instead it has 2
+    Expected function ... to have 2 arguments, instead it has 1
     """
     def _validate(func):
         # first, check that the function is callable

--- a/mitxgraders/plugins/integralgrader.py
+++ b/mitxgraders/plugins/integralgrader.py
@@ -378,7 +378,7 @@ class IntegralGrader(AbstractGrader):
                                           self.config['sample_from'],
                                           self.functions, {}, self.constants)
 
-        func_samples = gen_symbols_samples(self.random_funcs.keys(),
+        func_samples = gen_symbols_samples(list(self.random_funcs.keys()),
                                            self.config['samples'],
                                            self.random_funcs,
                                            self.functions, {}, {} )

--- a/mitxgraders/sampling.py
+++ b/mitxgraders/sampling.py
@@ -655,7 +655,7 @@ def gen_symbols_samples(symbols, samples, sample_from, functions, suffixes, cons
         }
         while unevaluated_dependents:
             progress_made = False
-            for symbol, dependencies in unevaluated_dependents.items():
+            for symbol, dependencies in list(unevaluated_dependents.items()):
                 if is_subset(dependencies, sample_dict):
                     sample_dict[symbol] = sample_from[symbol].compute_sample(
                         sample_dict, functions, suffixes)

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -446,10 +446,18 @@ def test_fg_custom_comparers():
         reduced = student_input % (360)
         return utils.within_tolerance(answer, reduced) and student_input > min_value
 
-    mocked = mock.Mock(side_effect=is_coterminal_and_large,
-                # The next two kwargs ensure that the Mock behaves nicely for inspect.getargspec
-                spec=is_coterminal_and_large,
-                func_code=is_coterminal_and_large.func_code,)
+    mocked = (mock.create_autospec(is_coterminal_and_large,
+                                   side_effect=is_coterminal_and_large)
+              if six.PY3 else
+              mock.Mock(side_effect=is_coterminal_and_large,
+                        # The next two kwargs ensure that the Mock behaves nicely
+                        # for inspect.getargspec in Python 2
+                        # but this does NOT work in Python 3, where create_autospec
+                        # is needed
+                        spec=is_coterminal_and_large,
+                        func_code=is_coterminal_and_large.__code__)
+             )
+
 
     grader = FormulaGrader(
         answers={

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -446,17 +446,17 @@ def test_fg_custom_comparers():
         reduced = student_input % (360)
         return utils.within_tolerance(answer, reduced) and student_input > min_value
 
-    mocked = (mock.create_autospec(is_coterminal_and_large,
-                                   side_effect=is_coterminal_and_large)
-              if six.PY3 else
-              mock.Mock(side_effect=is_coterminal_and_large,
-                        # The next two kwargs ensure that the Mock behaves nicely
-                        # for inspect.getargspec in Python 2
-                        # but this does NOT work in Python 3, where create_autospec
-                        # is needed
-                        spec=is_coterminal_and_large,
-                        func_code=is_coterminal_and_large.__code__)
-             )
+    if six.PY3:
+        mocked = mock.create_autospec(is_coterminal_and_large,
+                                      side_effect=is_coterminal_and_large)
+    else:
+        # The last two kwargs ensure that the Mock behaves nicely
+        # for inspect.getargspec in Python 2
+        # but this does NOT work in Python 3, where create_autospec
+        # is needed
+        mocked = mock.Mock(side_effect=is_coterminal_and_large,
+                           spec=is_coterminal_and_large,
+                           func_code=is_coterminal_and_large.__code__)
 
 
     grader = FormulaGrader(

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -8,6 +8,13 @@ import os
 import pytest
 import mitxgraders
 
+try:
+    # for Python 3
+    from importlib import reload
+except ImportError:
+    # reload is builtin in Python 2
+    pass
+
 @pytest.fixture()
 def loadzip():
     """pytest fixture to dynamically load the library from python_lib.zip"""


### PR DESCRIPTION
This PR removes numeric in-place operations from `expressions.py` (string `+=` ops are left in tact).

The motivation for this PR is a change in `numpy`'s behavior, illustrated below:

```
import numpy as np

A = np.array([1, 1, 1])

A *= 1.5; print(A)
# Numpy 1.6: array([1.5, 1.5, 1.5])
# Numpy 1.16: TypeError: Cannot cast ufunc multiply output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
```
Prior to numpy `1.10` (I believe), numpy was happy to re-cast arrays to arrays of a different type, in-place. 

This becomes a problem for us in situations like:
```python
import numpy as np
from mitxgraders.helpers.calc import evaluator

variables = {
    'A': np.array([1, 1, 1])
}
result, _ = evaluator('A/2', variables, {}, {})
# TypeError: ufunc 'true_divide' output (typecode 'd') could not be coerced to provided output parameter (typecode 'l') according to the casting rule ''same_kind''
```

# Maybe not necessary ... 
Really, people shouldn't be using `np.array`, they should be using our `MathArray`. It turns out that this change in numpy behavior is not a problem for `MathArray` since it's "in-place" operations (`__iadd__`, etc) are fake: they return new objects instead of modifying the original.

Still, this inconsistency in behavior makes me uncomfortable and I'd rather get rid of it. Maybe someone in the future will make `MathArray`'s `__iadd__` method truly in-place, or might find a reason to use numpy variables directly, or ... 

(Footnote: discoved while trying to fix test https://github.com/mitodl/mitx-grading-library/blob/32a66e19b1ea0b7939e0e88adc9edf4de6a3fe3c/tests/helpers/calc/test_expressions.py#L150)