### PR TITLE
Removing pylint from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,8 @@ pyparsing==2.0.7
 scipy==0.14.0
 six==1.11.0
 
-# For testing/linting
+# For testing
 mock
-pylint
 pytest==3.6.2
 pytest-cov==2.5.1
 

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -4,8 +4,7 @@ scipy==1.2.2
 pyparsing==2.4.0
 six==1.11.0
 
-# For testing/linting
-pylint
+# For testing
 pytest==3.6.2
 pytest-cov==2.5.1
 


### PR DESCRIPTION
I tried setting up a fresh install of this repo in python 2 and 3. The python 2 version is failing because pylint doesn't install properly. We're not actually using it, so I'm removing it from requirements.txt.