### PR TITLE
Adding plug-in to do global default overrides

### DIFF
--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -18,11 +18,18 @@ from mitxgraders.version import __version__
 from mitxgraders.exceptions import ConfigError, MITxError, StudentFacingError
 from mitxgraders.helpers.validatorfuncs import text_string, Positive
 
+class DefaultValuesMeta(abc.ABCMeta):
+    """
+    Metaclass that mixes ABCMeta behaviour and also provides a default_values parameter
+    to every subclass that is NOT shared with superclasses/subclasses.
+    """
+    def __init__(self, name, bases, attrs):
+        self.default_values = None
+        super(DefaultValuesMeta, self).__init__(name, bases, attrs)
+
+@six.add_metaclass(DefaultValuesMeta)  # This is an abstract base class with default_values
 class ObjectWithSchema(object):
     """Represents an author-facing object whose configuration needs validation."""
-
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractproperty
     def schema_config(self):
@@ -40,15 +47,76 @@ class ObjectWithSchema(object):
         """
         return voluptuous_validate(config, self.schema_config)
 
+    @classmethod
+    def register_defaults(cls, values_dict):
+        """Saves a dictionary of values to override the defaults"""
+        if cls.default_values is None:
+            cls.default_values = {}
+        cls.default_values.update(values_dict)
+
+    @classmethod
+    def clear_registered_defaults(cls):
+        """Clears all registered defaults"""
+        cls.default_values = None
+
     def __init__(self, config=None, **kwargs):
         """
         Validate the supplied config for the object, using either a config dict or kwargs,
-        but not both.
+        but not both. Also loads any registered defaults.
         """
+        # Select the appropriate source for configuration
         if config is None:
-            self.config = self.validate_config(kwargs)
+            use_config = kwargs
         else:
-            self.config = self.validate_config(config)
+            use_config = config
+
+        # Apply any registered defaults before overriding with the given configuration
+        if isinstance(use_config, dict):
+            use_config = self.apply_registered_defaults(use_config)
+
+        # Validate the configuration
+        self.config = self.validate_config(use_config)
+
+    def apply_registered_defaults(self, config):
+        """
+        Apply the registered defaults of this class and all superclasses to the
+        configuration, then return the resulting configuration.
+        """
+        # Initialize a storage list
+        config_dicts = []
+        config_dicts.append(self.default_values)
+
+        # Traverse the super classes to obtain default_values from all super classes
+        current_class = self.__class__
+        while True:
+            # We never use multiple inheritance, so just follow the chain
+            current_class = current_class.__bases__[0]
+            config_dicts.append(current_class.default_values)
+            if current_class == ObjectWithSchema:
+                break
+
+        # Go and apply all the default_values in reverse order
+        base = {}
+        config_dicts.reverse()
+        for entry in config_dicts:
+            if entry is not None:
+                base.update(entry)
+
+        # Report that modified defaults are being used
+        self.save_modified_defaults(config_dicts)
+
+        # Apply the provided configuration
+        base.update(config)
+
+        # Return the resulting configuration
+        return base
+
+    def save_modified_defaults(self, config):
+        """
+        Allows an ObjectWithSchema to save any modified defaults for later use.
+        This function is intended to be shadowed as necessary.
+        """
+        pass
 
     def __repr__(self):
         """Printable representation of the object"""
@@ -96,9 +164,6 @@ class AbstractGrader(ObjectWithSchema):
         attempt_based_credit_msg (bool): When maximum credit has been decreased due to
             attempt number, present the student with a message explaining so (default True)
     """
-
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractproperty
     def schema_config(self):
@@ -300,6 +365,12 @@ class AbstractGrader(ObjectWithSchema):
         content = "\n".join(self.debuglog)
         return "<pre>{content}</pre>".format(content=content)
 
+    def save_modified_defaults(self, config):
+        """
+        Make a copy of the modified defaults for future logging purposes.
+        """
+        self.modified_defaults = config.copy()
+
     @staticmethod
     def ensure_text_inputs(student_input, allow_lists=True, allow_single=True):
         """
@@ -374,9 +445,6 @@ class ItemGrader(AbstractGrader):
         wrong_msg (str): A generic message to give the students upon submission of an
             answer that received a grade of 0 (default "")
     """
-
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
 
     @property
     def schema_config(self):

--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -103,7 +103,7 @@ class ObjectWithSchema(object):
                 base.update(entry)
 
         # Report that modified defaults are being used
-        self.save_modified_defaults(config_dicts)
+        self.save_modified_defaults(base)
 
         # Apply the provided configuration
         base.update(config)

--- a/mitxgraders/comparers/baseclasses.py
+++ b/mitxgraders/comparers/baseclasses.py
@@ -16,9 +16,6 @@ class Comparer(ObjectWithSchema):
     This class is abstract. Comparers should inherit from it.
     """
 
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def __call__(self, comparer_params_eval, student_eval, utils):
         """
@@ -47,9 +44,6 @@ class CorrelatedComparer(Comparer):
 
     This class is abstract. Correlated Comparers should inherit from it.
     """
-
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def __call__(self, comparer_params_evals, student_evals, utils):

--- a/mitxgraders/matrixsampling.py
+++ b/mitxgraders/matrixsampling.py
@@ -15,7 +15,6 @@ Contains classes for sampling vector/matrix/tensor values:
 All of these classes perform random sampling. To obtain a sample, use class.gen_sample()
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
-import abc
 import numpy as np
 
 class Unavailable(object):
@@ -65,7 +64,8 @@ class ArraySamplingSet(VariableSamplingSet):
     The norm used is standard Euclidean norm: root-square-sum of all entries in the array.
 
     This is the most low-level array sampling set we have, and is subclassed for various
-    specific purposes.
+    specific purposes. While we cannot make this class abstract, we strongly discourage
+    its use.
 
     Config:
     =======
@@ -77,8 +77,6 @@ class ArraySamplingSet(VariableSamplingSet):
             (default [1, 5])
         - complex (bool): Whether or not the matrix is complex (default False)
     """
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
 
     schema_config = Schema({
         Required('shape'): is_shape_specification(min_dim=1),
@@ -162,8 +160,8 @@ class ArraySamplingSet(VariableSamplingSet):
 
 class VectorSamplingSet(ArraySamplingSet):
     """
-    Sampling set of vectors. This is an abstract class; you should use RealVectors or
-    ComplexVectors instead.
+    Sampling set of vectors. While we cannot make this class abstract, you should use
+    RealVectors or ComplexVectors instead.
 
     Config:
     =======
@@ -172,8 +170,6 @@ class VectorSamplingSet(ArraySamplingSet):
             - if shape is tuple/list, must have length 1
             - default shape is (3, ), for a 3D vector
     """
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
 
     schema_config = ArraySamplingSet.schema_config.extend({
         Required('shape', default=(3,)): is_shape_specification(min_dim=1, max_dim=1)
@@ -227,16 +223,14 @@ class ComplexVectors(VectorSamplingSet):
 
 class TensorSamplingSet(ArraySamplingSet):
     """
-    Sampling set of tensors. This is an abstract class; you should use RealTensors or
-    ComplexTensors instead.
+    Sampling set of tensors. While we cannot make this class abstract, you should use
+    RealTensors or ComplexTensors instead.
 
     Config:
     =======
         Same as ArraySamplingSet, but:
             - shape must be a tuple with at least 3 dimensions
     """
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
 
     schema_config = ArraySamplingSet.schema_config.extend({
         Required('shape'): is_shape_specification(min_dim=3)
@@ -305,7 +299,7 @@ class ComplexTensors(TensorSamplingSet):
 
 class MatrixSamplingSet(ArraySamplingSet):
     """
-    Base sampling set of matrices. This is an abstract base class; you should
+    Base sampling set of matrices. While we cannot make this class abstract, you should
     use a more specific subclass instead.
 
     Config:
@@ -315,8 +309,6 @@ class MatrixSamplingSet(ArraySamplingSet):
             - default shape is (2, 2), for a 2x2 matrix
 
     """
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
 
     schema_config = ArraySamplingSet.schema_config.extend({
         Required('shape', default=(2, 2)): is_shape_specification(min_dim=2, max_dim=2)
@@ -325,7 +317,7 @@ class MatrixSamplingSet(ArraySamplingSet):
 
 class GeneralMatrices(MatrixSamplingSet):
     """
-    Base sampling set of general matrices. This is an abstract base class; you
+    Base sampling set of general matrices. While we cannot make this class abstract, you
     should use RealMatrices or ComplexMatrices instead.
 
     Config:
@@ -334,8 +326,6 @@ class GeneralMatrices(MatrixSamplingSet):
             - triangular (None, 'upper', 'lower'): Specify if you want a triangular
                 matrix (default None)
     """
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
 
     schema_config = MatrixSamplingSet.schema_config.extend({
         Required('triangular', default=None): Any(None, 'upper', 'lower')
@@ -411,8 +401,8 @@ class ComplexMatrices(GeneralMatrices):
 
 class SquareMatrixSamplingSet(MatrixSamplingSet):
     """
-    Base sampling set of square matrices. This is an abstract base class. You want to use
-    a subclass instead (likely SquareMatrices).
+    Base sampling set of square matrices. While we cannot make this class abstract, you
+    want to use a subclass instead (likely SquareMatrices).
 
     Config:
     =======
@@ -421,8 +411,6 @@ class SquareMatrixSamplingSet(MatrixSamplingSet):
 
     The 'shape' property is not used.
     """
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
 
     schema_config = MatrixSamplingSet.schema_config.extend({
         Required('shape', default=None): None,

--- a/mitxgraders/plugins/defaults_sample.py
+++ b/mitxgraders/plugins/defaults_sample.py
@@ -1,0 +1,51 @@
+"""
+defaults_sample.py
+
+This plug-in can be used to set course-wide defaults for a given grading class.
+
+We recommend copying this file (so that upgrading the library won't overwrite it),
+renaming it to defaults.py, and modifying it according to your needs.
+
+This plug-in works by registering a dictionary with the appropriate grading class (note,
+not class instance).
+"""
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+# Here are all of the graders that you can specify defaults for
+from mitxgraders.stringgrader import StringGrader
+from mitxgraders.baseclasses import AbstractGrader, ItemGrader
+from mitxgraders.listgrader import ListGrader, SingleListGrader
+from mitxgraders.plugins.integralgrader import IntegralGrader
+from mitxgraders.formulagrader.formulagrader import FormulaGrader, NumericalGrader
+from mitxgraders.formulagrader.matrixgrader import MatrixGrader
+
+# These modifications are commented out so that they don't override the normal defaults.
+# To use them, you need to uncomment them.
+
+# Change case_sensitive to False by default
+# StringGrader.register_defaults({
+#     'case_sensitive': False
+# })
+
+# Turn on attempt-based partial credit by default and modify related settings
+# This will turn on attempt-based partial credit for all graders
+# AbstractGrader.register_defaults({
+#     'attempt_based_credit': True,
+#     'decrease_credit_after': 1,
+#     'minimum_credit': 0.5,
+#     'decrease_credit_steps': 1,
+#     'attempt_based_credit_msg': True
+# })
+# Note that if you do this, you will need to either pass cfn_extra_args="attempt" in every
+# customresponse tag or explicitly disable attempt-based credit.
+
+# Note that registered defaults can be applied to a higher level class than where those
+# options normally live. For example, to turn on debug by default in all StringGrader
+# instances (debug is defined in AbstractGrader), you can do the following:
+# StringGrader.register_defaults({
+#     'debug': True
+# })
+
+# Precedence is given to the registered defaults of higher level classes. If
+# register_defaults is called twice on the same class, the options stack on top of
+# each other, overwriting earlier options as necessary.

--- a/mitxgraders/plugins/template.py
+++ b/mitxgraders/plugins/template.py
@@ -5,7 +5,6 @@ mechanism is working.
 from __future__ import print_function, division, absolute_import, unicode_literals
 
 # Make sure that imports are working
-
 from mitxgraders.baseclasses import ItemGrader
 
 def plugin_test():

--- a/mitxgraders/sampling.py
+++ b/mitxgraders/sampling.py
@@ -55,10 +55,11 @@ def set_seed(seed=None):
     np.random.seed(seed)
 
 class AbstractSamplingSet(ObjectWithSchema):  # pylint: disable=abstract-method
-    """Represents a set from which random samples are taken."""
+    """
+    Represents a set from which random samples are taken.
 
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
+    Note that this is an abstract class.
+    """
 
     @abc.abstractmethod
     def gen_sample(self):
@@ -66,24 +67,27 @@ class AbstractSamplingSet(ObjectWithSchema):  # pylint: disable=abstract-method
 
 
 class VariableSamplingSet(AbstractSamplingSet):  # pylint: disable=abstract-method
-    """Represents a set from which random variable samples are taken."""
+    """
+    Represents a set from which random variable samples are taken.
 
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
+    Note that this is an abstract class.
+    """
 
 
 class ScalarSamplingSet(VariableSamplingSet):  # pylint: disable=abstract-method
-    """Represents a set from which random scalar variable samples are taken."""
+    """
+    Represents a set from which random scalar variable samples are taken.
 
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
+    Note that this is an abstract class.
+    """
 
 
 class FunctionSamplingSet(AbstractSamplingSet):  # pylint: disable=abstract-method
-    """Represents a set from which random function samples are taken."""
+    """
+    Represents a set from which random function samples are taken.
 
-    # This is an abstract base class
-    __metaclass__ = abc.ABCMeta
+    Note that this is an abstract class.
+    """
 
 
 class RealInterval(ScalarSamplingSet):


### PR DESCRIPTION
Pretty much what it says in the title.

This was a tricky little thing to get right, and involved my first ever use of my own metaclass. The basic idea is to have a `default_values` property associated with each class (not class instance, but _class_; hence the need for a metaclass). Then, right before schema validation, look up the class `default_values` property, _and all of the superclasses_, to construct the complete configuration. I think the end result is really neat though, and provides a really easy way to set global defaults.

Resolves #249.