### PR TITLE
Adding instructor variables back in to debug output

### DIFF
--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -783,7 +783,8 @@ class FormulaGrader(ItemGrader):
             student_evals.append(student_eval)
 
             if self.config['debug']:
-                # Put the siblings back in for the debug output
+                # Put the siblings and instructor variables back in for the debug output
+                varlist.update(var_samples[i])
                 varlist.update(siblings_eval)
                 self.log_eval_info(i, varlist, funclist, comparer_params_eval, student_eval)
 


### PR DESCRIPTION
This fixes a small issue with the implementation of instructor variables: they need to be added back in to the debug output. I haven't made a test to fix this, because it's one of those functiongrader debug log things (I was going to co-opt the corresponding sibling variable test, but found that there wasn't one for that either!).