### PR TITLE
Infer answers from expect values for SingleListGrader

### DIFF
--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -652,23 +652,23 @@ class ItemGrader(AbstractGrader):
         """
         The same as AbstractGrader.__call__, except that we try to infer
         answers from expect argument if answers are not specified in the
-        grader configuration. The actual inference is done by infer_answers,
+        grader configuration. The actual inference is done by infer_from_expect,
         which can be shadowed.
         """
         # If expect is provided, infer an answer if we either don't have an answer or
         # are always inferring answers
         if expect is not None and (self.inferring_answers or not self.config['answers']):
-            self.config['answers'] = self.infer_answers(expect)
+            inferred = self.infer_from_expect(expect)
 
             # Create the debug log...
             self.create_debuglog(student_input)
             # ... so that we can add the inferred answers to it before
             # calling AbstractGrader.__call__
-            output = json.dumps(self.config['answers'])  # How to avoid unicode 'u' showing up!
-            self.log("Answer inferred to be {}".format(output))
+            output = json.dumps(inferred)  # How to avoid unicode 'u' showing up!
+            self.log("Expect value inferred to be {}".format(output))
 
             # Validate the answers
-            self.config['answers'] = self.schema_answers(self.config['answers'])
+            self.config['answers'] = self.schema_answers(inferred)
             # Note that this answer is now stored for future calls, but
             # will be overridden if a new expect value is provided.
 
@@ -678,13 +678,13 @@ class ItemGrader(AbstractGrader):
         # And punt the actual __call__ function to the superclass
         return super(ItemGrader, self).__call__(expect, student_input, **kwargs)
 
-    def infer_answers(self, expect):
+    def infer_from_expect(self, expect):
         """
-        Infer answer from the expect parameter and return it. For most purposes,
+        Infer the answer from the expect parameter and return it. For most purposes,
         the answer is just the expect parameter. However, this can be shadowed if need be.
 
-        If you create a grader that cannot infer answers, shadow this function, and simply
-        raise ConfigError('Answer cannot be inferred for this grader')
+        If you create a grader that cannot infer from expect, shadow this function, and
+        simply raise ConfigError('Answer cannot be inferred for this grader')
         """
         return expect
 

--- a/mitxgraders/listgrader.py
+++ b/mitxgraders/listgrader.py
@@ -740,12 +740,12 @@ class SingleListGrader(ItemGrader):
 
         return result
 
-    def infer_answers(self, expect):
+    def infer_from_expect(self, expect):
         """
         Infer answers from the expect parameter, following nested SingleListGrader
         chains through recursion. Returns the resulting answers key.
 
-        Shadows the ItemGrader infer_answers function.
+        Shadows the ItemGrader infer_from_expect function.
 
         For example, we want to turn
         'a, b; c, d' -> [['a', 'b'], ['c', 'd']]
@@ -757,7 +757,7 @@ class SingleListGrader(ItemGrader):
         # If the subgrader is also a SingleListGrader, recurse on each element of answers
         if isinstance(self.config['subgrader'], SingleListGrader):
             for idx, entry in enumerate(answers):
-                answers[idx] = self.config['subgrader'].infer_answers(entry)
+                answers[idx] = self.config['subgrader'].infer_from_expect(entry)
 
         # Return the result
         return answers

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -66,7 +66,7 @@ def test_debug_with_input_list():
     debug_content = "Student Responses:\ncat\nfish\ndog"
     msg = template.format(version=__version__,
                           debug_content=debug_content
-                         ).replace("\n", "<br/>\n")
+                          ).replace("\n", "<br/>\n")
     expected_result = {
         'overall_message': msg,
         'input_list': [
@@ -135,15 +135,15 @@ def test_itemgrader_infers_answers_from_expect():
     # answer, and that newly provided answers override the old ones.
     result = grader('cat', 'cat')
     assert result['ok']
-    assert 'Answer inferred to be "cat"' in result['msg']
+    assert 'Expect value inferred to be "cat"' in result['msg']
 
     result = grader(None, 'cat')
     assert result['ok']
-    assert 'Answer inferred to be "cat"' not in result['msg']
+    assert 'Expect value inferred to be "cat"' not in result['msg']
 
     result = grader('dog', 'dog')
     assert result['ok']
-    assert 'Answer inferred to be "dog"' in result['msg']
+    assert 'Expect value inferred to be "dog"' in result['msg']
 
 def test_single_expect_value_in_config():
     grader = StringGrader(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -48,7 +48,7 @@ def test_debug_without_author_message():
     debug_content = "Student Response:\nhorse"
     msg = template.format(version=__version__,
                           debug_content=debug_content
-                         ).replace("\n", "<br/>\n")
+                          ).replace("\n", "<br/>\n")
     expected_result = {'msg': msg, 'grade_decimal': 0, 'ok': False}
     assert grader(None, student_response) == expected_result
 
@@ -124,12 +124,26 @@ def test_itemgrader():
     assert not grader(None, "3")['ok']
 
 def test_itemgrader_infers_answers_from_expect():
-    grader = StringGrader()
+    grader = StringGrader(debug=True)
     expect = 'cat'
     student_input_1 = 'cat'
     student_input_2 = 'dog'
     assert grader(expect, student_input_1)['ok']
     assert not grader(expect, student_input_2)['ok']
+
+    # Test that once an answer is inferred, subsequent calls to the grader remember that
+    # answer, and that newly provided answers override the old ones.
+    result = grader('cat', 'cat')
+    assert result['ok']
+    assert 'Answer inferred to be "cat"' in result['msg']
+
+    result = grader(None, 'cat')
+    assert result['ok']
+    assert 'Answer inferred to be "cat"' not in result['msg']
+
+    result = grader('dog', 'dog')
+    assert result['ok']
+    assert 'Answer inferred to be "dog"' in result['msg']
 
 def test_single_expect_value_in_config():
     grader = StringGrader(
@@ -572,3 +586,12 @@ def test_registered_defaults():
     grader = StringGrader()
     assert grader.config['debug']
     StringGrader.clear_registered_defaults()
+
+def test_debuglog_persistence():
+    # Or rather, lack thereof
+    grader = StringGrader(debug=True)
+    grader('cat', 'cat')
+    log1 = grader.debuglog
+    grader('cat', 'cat')
+    # Demand that the debug logs are different objects
+    assert log1 is not grader.debuglog

--- a/tests/test_singlelistgrader.py
+++ b/tests/test_singlelistgrader.py
@@ -388,19 +388,19 @@ def test_infer_expect():
         delimiter=';',
         debug=True
     )
-    assert grader.infer_answers('a,b;c,d') == [['a', 'b'], ['c', 'd']]
-    assert grader.infer_answers('a,b,c;d,e,f;g,h,i') == [['a', 'b', 'c'],
-                                                         ['d', 'e', 'f'],
-                                                         ['g', 'h', 'i']]
+    assert grader.infer_from_expect('a,b;c,d') == [['a', 'b'], ['c', 'd']]
+    assert grader.infer_from_expect('a,b,c;d,e,f;g,h,i') == [['a', 'b', 'c'],
+                                                             ['d', 'e', 'f'],
+                                                             ['g', 'h', 'i']]
     # Test that the grading process works
     assert grader('a,b;c,d', 'd,c;b,a')['ok']
     # Test that inferred answers show up in the debug log as expected
     msg = grader('a,b;c,d', 'a')['msg']
-    assert 'Answer inferred to be [["a", "b"], ["c", "d"]]' in msg
+    assert 'Expect value inferred to be [["a", "b"], ["c", "d"]]' in msg
     msg = grader('a,b', 'a')['msg']
-    assert 'Answer inferred to be [["a", "b"]]' in msg
+    assert 'Expect value inferred to be [["a", "b"]]' in msg
     msg = grader('a;b', 'a')['msg']
-    assert 'Answer inferred to be [["a"], ["b"]]' in msg
+    assert 'Expect value inferred to be [["a"], ["b"]]' in msg
 
     # Test heavy nesting
     grader = SingleListGrader(
@@ -413,5 +413,5 @@ def test_infer_expect():
         ),
         delimiter=';'
     )
-    assert grader.infer_answers('a-1-@,b-2;c-3,d-4') == [[['a', '1', '@'], ['b', '2']],
-                                                         [['c', '3'], ['d', '4']]]
+    assert grader.infer_from_expect('a-1-@,b-2;c-3,d-4') == [[['a', '1', '@'], ['b', '2']],
+                                                             [['c', '3'], ['d', '4']]]


### PR DESCRIPTION
This PR generalizes the implementation of reading the `expect` keyword to infer answers. In particular, it does the following:

* Makes it explicit that once an answer is inferred, that answer is stored in the configuration
* Ensures that when answers are being inferred, newly-provided `expect` parameters override the old ones
* Adds the inferred answers to the debug log
* Generalizes the debug log implementation slightly to provide access to it before the `AbstractGrader.__call__` function is called, while ensuring that the log is cleared between calls to a grader
* Implements answer inference as a shadowable function
* Implements answer inference for `SingleListGrader`
* Implements proper delimiter checking across nested `SingleListGrader`s