### PR TITLE
Linking coverage badge to coverage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MITx Grading Library
 
-[![Build Status](https://travis-ci.org/mitodl/mitx-grading-library.svg?branch=master)](https://travis-ci.org/mitodl/mitx-grading-library) ![Coverage Status](https://codecov.io/gh/mitodl/mitx-grading-library/branch/master/graphs/badge.svg)
+[![Build Status](https://travis-ci.org/mitodl/mitx-grading-library.svg?branch=master)](https://travis-ci.org/mitodl/mitx-grading-library) [![Coverage Status](https://codecov.io/gh/mitodl/mitx-grading-library/branch/master/graphs/badge.svg)](https://codecov.io/gh/mitodl/mitx-grading-library)
 
 A library of graders for edX Custom Response problems.
 


### PR DESCRIPTION
Just fixing the `README.md` file so that the coverage badge links to codecov.io.