### PR TITLE
Expanding SpecifyDomain to allow for functions with any number of arguments of a given shape

### DIFF
--- a/mitxgraders/helpers/calc/mathfuncs.py
+++ b/mitxgraders/helpers/calc/mathfuncs.py
@@ -275,11 +275,19 @@ ELEMENTWISE_FUNCTIONS = {
 def has_one_scalar_input(display_name):
     return SpecifyDomain.make_decorator((1,), display_name=display_name)
 
+def has_at_least_2_scalar_inputs(display_name):
+    return SpecifyDomain.make_decorator((1,), display_name=display_name, min_length=2)
+
 SCALAR_FUNCTIONS = {key: has_one_scalar_input(key)(ELEMENTWISE_FUNCTIONS[key])
                     for key in ELEMENTWISE_FUNCTIONS}
 
 SCALAR_FUNCTIONS['arctan2'] = arctan2
 SCALAR_FUNCTIONS['kronecker'] = kronecker
+
+MULTI_SCALAR_FUNCTIONS = {
+    'min': has_at_least_2_scalar_inputs('min')(min),
+    'max': has_at_least_2_scalar_inputs('max')(max)
+}
 
 ARRAY_FUNCTIONS = {
     're': real,
@@ -323,7 +331,7 @@ def merge_dicts(*source_dicts):
         target.update(source)
     return target
 
-DEFAULT_FUNCTIONS = merge_dicts(SCALAR_FUNCTIONS, ARRAY_FUNCTIONS)
+DEFAULT_FUNCTIONS = merge_dicts(SCALAR_FUNCTIONS, MULTI_SCALAR_FUNCTIONS, ARRAY_FUNCTIONS)
 
 DEFAULT_SUFFIXES = {
     '%': 0.01

--- a/mitxgraders/helpers/calc/specify_domain.py
+++ b/mitxgraders/helpers/calc/specify_domain.py
@@ -9,9 +9,10 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 from numbers import Number
 from voluptuous import Schema, Invalid, Required, Any
 from mitxgraders.helpers.compatibility import wraps
-from mitxgraders.helpers.validatorfuncs import is_shape_specification, Nullable, text_string
+from mitxgraders.helpers.validatorfuncs import is_shape_specification, Nullable, text_string, Positive
 from mitxgraders.baseclasses import ObjectWithSchema
 from mitxgraders.helpers.calc.exceptions import ArgumentShapeError, ArgumentError
+from mitxgraders.exceptions import ConfigError
 from mitxgraders.helpers.calc.math_array import (
     MathArray, is_numberlike_array, is_square)
 from mitxgraders.helpers.calc.formatters import get_description
@@ -145,7 +146,7 @@ class SpecifyDomain(ObjectWithSchema):
     An author-facing, configurable decorator that validates the inputs
     of the decorated function.
 
-    For now, the only validation available is shape-validation.
+    Performs shape validation and number-of-arguments validation.
 
     Configuration
     =============
@@ -157,6 +158,10 @@ class SpecifyDomain(ObjectWithSchema):
         'square' indicates a square matrix of any dimension
     - display_name (?str): Function name to be used in error messages
       defaults to None, meaning that the function's __name__ attribute is used.
+    - min_length (None or int): If None, inputs must match the exact shape specified by
+        input_shapes. If a positive integer, input_shapes must have a single entry,
+        and the function will accept any number of entries with that shape (minimum min_length).
+        (default None)
 
     Basic Usage:
     ============
@@ -209,21 +214,50 @@ class SpecifyDomain(ObjectWithSchema):
     2nd input has an error: received a scalar, expected a matrix of shape (rows: 3, cols: 2)
     3rd input has an error: received a scalar, expected a vector of length 2
     4th input is ok: received a square matrix as expected
+
+    To specify that a function should be allowed to take any number of inputs of a certain
+    shape, input_shapes should have a single entry, and set min_length to the minimum
+    number of arguments (at least 1).
+    >>> @SpecifyDomain(input_shapes=[1], min_length=2)  # Any number of scalars
+    ... def my_min(*args):
+    ...     return min(*args)
+    >>> my_min(1, 2, 3)
+    1
+    >>> my_min(2, 3, 4, 5, 6, 7, 8)
+    2
+    >>> try:
+    ...     my_min(MathArray([[1, 1], [0, 1]]), 2, 3, 4)
+    ... except ArgumentShapeError as error:
+    ...     print(error)
+    There was an error evaluating function my_min(...)
+    1st input has an error: received a matrix of shape (rows: 2, cols: 2), expected a scalar
+    2nd input is ok: received a scalar as expected
+    3rd input is ok: received a scalar as expected
+    4th input is ok: received a scalar as expected
     """
 
     schema_config = Schema({
         Required('input_shapes'): [Schema(
             Any(is_shape_specification(), 'square')
         )],
-        Required('display_name', default=None): Nullable(text_string)
+        Required('display_name', default=None): Nullable(text_string),
+        Required('min_length', default=None): Nullable(Positive(int))
     })
 
     def __init__(self, config=None, **kwargs):
         super(SpecifyDomain, self).__init__(config, **kwargs)
 
-        display_name = self.config['display_name']
         shapes = self.config['input_shapes']
-        self.decorate = self.make_decorator(*shapes, display_name=display_name)
+
+        # Check that min_length is compatible with the provided shapes
+        if self.config['min_length'] is not None and len(shapes) != 1:
+            raise ConfigError("SpecifyDomain was called with a specified min_length, which "
+                              "requires input_shapes to specify only a single shape. "
+                              "However, {} shapes were provided.".format(len(shapes)))
+
+        self.decorate = self.make_decorator(*shapes,
+                                            display_name=self.config['display_name'],
+                                            min_length=self.config['min_length'])
 
     def __call__(self, func):
         return self.decorate(func)
@@ -237,9 +271,12 @@ class SpecifyDomain(ObjectWithSchema):
 
         Used internally in mitxgraders library.
         """
-
         display_name = kwargs.get('display_name', None)
-        schemas = [Schema(has_shape(shape)) for shape in shapes]
+        min_length = kwargs.get('min_length', None)
+        if min_length is not None:
+            any_schema = Schema(has_shape(shapes[0]))
+        else:
+            len_schema = [Schema(has_shape(shape)) for shape in shapes]
 
         # can't use @wraps, func might be a numpy ufunc
         def decorator(func):
@@ -247,12 +284,29 @@ class SpecifyDomain(ObjectWithSchema):
 
             @wraps(func)
             def _func(*args):
-                if len(shapes) != len(args):
-                    # Use the same response as in validate_function_call in expressions.py
-                    msg = ("Wrong number of arguments passed to {func_name}(...): "
-                           "Expected {expected} inputs, but received {received}."
-                           .format(func_name=func_name, expected=len(shapes), received=len(args))
-                           )
+                # Set up the schemas and shapes for validation.
+                # Also check the number of arguments provided is correct.
+                # Use the same response as in validate_function_call in expressions.py
+                msg = ''
+                if min_length is not None:
+                    schemas = [any_schema] * len(args)
+                    use_shapes = [shapes[0]] * len(args)
+                    if len(args) < min_length:
+                        msg = ("Wrong number of arguments passed to {func_name}(...): "
+                               "Expected at least {expected} inputs, but received {received}."
+                               .format(func_name=func_name,
+                                       expected=min_length,
+                                       received=len(args)))
+                else:
+                    schemas = len_schema
+                    use_shapes = shapes
+                    if len(shapes) != len(args):
+                        msg = ("Wrong number of arguments passed to {func_name}(...): "
+                               "Expected {expected} inputs, but received {received}."
+                               .format(func_name=func_name,
+                                       expected=len(shapes),
+                                       received=len(args)))
+                if msg:
                     raise ArgumentError(msg)
 
                 errors = []
@@ -267,7 +321,7 @@ class SpecifyDomain(ObjectWithSchema):
                     return func(*args)
 
                 lines = ['There was an error evaluating function {0}(...)'.format(func_name)]
-                for index, (shape, error) in enumerate(zip(shapes, errors)):
+                for index, (shape, error) in enumerate(zip(use_shapes, errors)):
                     ordinal = low_ordinal(index + 1)
                     if error:
                         lines.append('{0} input has an error: '.format(ordinal) + error.error_message)

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -543,6 +543,8 @@ def test_fg_debug_log():
     " {u}'ln': <function log at 0x...>,<br/>\n"
     " {u}'log10': <function log10 at 0x...>,<br/>\n"
     " {u}'log2': <function log2 at 0x...>,<br/>\n"
+    " {u}'max': <function max at 0x...>,<br/>\n"
+    " {u}'min': <function min at 0x...>,<br/>\n"
     " {u}'re': <function real at 0x...>,<br/>\n"
     " {u}'sec': <function sec at 0x...>,<br/>\n"
     " {u}'sech': <function sech at 0x...>,<br/>\n"

--- a/tests/helpers/calc/test_expressions.py
+++ b/tests/helpers/calc/test_expressions.py
@@ -199,7 +199,6 @@ def test_suffix_capitalization_error():
     with raises(CalcError, match=match):
         evaluator('5m', variables, functions, suffixes)
 
-
 def test_floor2ceiling():
     value, used = evaluator('floor(1.5)')
     assert value == 1
@@ -220,3 +219,30 @@ def test_floor2ceiling():
            "Its input does not seem to be in its domain.")
     with raises(CalcError, match=msg):
         evaluator('ceil(1+i)')
+
+def test_min_max():
+    assert evaluator('min(1.5, 2, 4, 3.7, 9)')[0] == 1.5
+    assert evaluator('min(1.5, -2, 4, -3.7, 9)')[0] == -3.7
+
+    msg = (r"There was an error evaluating min\(...\). "
+           r"Its input does not seem to be in its domain.")
+    with raises(CalcError, match=msg):
+        evaluator('min(1+i, 2)')
+
+    msg = (r"Wrong number of arguments passed to min\(...\): "
+           r"Expected at least 2 inputs, but received 1.")
+    with raises(ArgumentError, match=msg):
+        evaluator('min(1.5)')
+
+    assert evaluator('max(1.5, 2, 4, 3.7, 9)')[0] == 9
+    assert evaluator('max(1.5, -2, 4, -3.7, 9)')[0] == 9
+
+    msg = (r"There was an error evaluating max\(...\). "
+           r"Its input does not seem to be in its domain.")
+    with raises(CalcError, match=msg):
+        evaluator('max(1+i, 2)')
+
+    msg = (r"Wrong number of arguments passed to max\(...\): "
+           r"Expected at least 2 inputs, but received 1.")
+    with raises(ArgumentError, match=msg):
+        evaluator('max(1.5)')


### PR DESCRIPTION
Resolves #166 by allowing SpecifyDomain to have a `min_length` argument.

Also incorporates math functions `min` and `max`.