### PR TITLE
Non-mathy and non-listy documentation

### DIFF
--- a/docs/edx.md
+++ b/docs/edx.md
@@ -30,7 +30,7 @@ grader = FormulaGrader(variables=["x"])
 </problem>
 ```
 
-Note that the `customresponse` tag contains the answer that is passed to the grader. You can also use `expect="2*x"` instead of `answer="2*x"`; edX treats these parameters indistinguishably (although we strongly suggest not using both!). Also note that a grader can be reused if desired.
+Note that the `customresponse` tag contains the answer that is passed to the grader. You can also use `expect="2*x"` instead of `answer="2*x"`; edX treats these parameters indistinguishably (although we strongly suggest not using both!). Also note that a grader can be used multiple times if desired.
 
 
 ## Using an answers key to a grader
@@ -42,40 +42,41 @@ If you provide an `answers` key to the grader, it will ignore whatever is specif
 
 <script type="loncapa/python">
 from mitxgraders import *
-grader = FormulaGrader(
-    answers={'expect': '2*x', 'ok': True, 'grade_decimal': 1, 'msg': 'Good job!'},
+mygrader = FormulaGrader(
+    answers={'expect': '2*x', 'msg': 'Good job!'},
     variables=['x']
 )
 </script>
 
   <p>Enter the derivative of \(x^2\).</p>
 
-  <customresponse cfn="grader" answer="2*x">
+  <customresponse cfn="mygrader" answer="2*x">
     <textline math="true" />
   </customresponse>
 
 </problem>
 ```
 
-Even though the `answers` key is provided to the grader explicitly, the `answer` parameter in the `customresponse` tag is still important, as it is what the students see when they click on "Show Answer".
+The `answers` key is provided to the grader explicitly, and so it ignores whatever is in the `customresponse` tag. However, the `answer` key in the `customresponse` tag is still important, because it is what the students see when they click on "Show Answer".
+
+Also worth noting is that the grader is stored in a python variable, which in this example, we've called `mygrader` (the previous example just called it `grader`). The `cfn` key in the `customresponse` tag needs to tell edX which variable stores the grader you want to use for that problem. If you have multiple `customresponse` tags, you can provide a different grader to each one.
 
 
 ## Using `correct_answer` for multiple inputs
 
-If you are using multiple inputs (such as when using a `ListGrader`) or a `SingleListGrader`, you must provide the `answers` key to the grader explicitly, as the `expect` or `answer` parameters in the `customresponse` tag are ignored. When using multiple inputs, it's recommended to provide a `correct_answer` parameter on the `textline` tags, which is what is used to show students the correct answer. Here is an example.
+If you are using multiple inputs (such as when using a `ListGrader`) or a `SingleListGrader`, you must provide the `answers` key to the grader explicitly, as the `expect` or `answer` parameters in the `customresponse` tag are ignored by both edX and the grader. When using multiple inputs, it's recommended to provide a `correct_answer` parameter on the `textline` tags, which is what is used to show students the correct answer. Here is an example.
 
 ```XML
 <problem>
 <script type="loncapa/python">
 from mitxgraders import *
-grader = FormulaGrader(
+grader = ListGrader(
     answers=['x-2', 'x+2'],
-    ordered=False,
     subgraders=FormulaGrader(variables=['x'])
 )
 </script>
 
-  <p>What are the linear factors of \((x^2 - 4)\)?</p>
+  <p>What are the linear factors of \((x^2 - 4)\)? Enter your answers in any order.</p>
 
   <!-- Note there is no 'expect' or 'answer' parameter in the customresponse tag -->
   <customresponse cfn="grader">
@@ -90,12 +91,12 @@ grader = FormulaGrader(
 
 Note that the `correct_answer` parameters are never sent to the grader, which is why you must provide them independently.
 
-When using sublists, such as a `ListGrader` or a `SingleListGrader` inside a `ListGrader`, you only need to provide an `answers` key to the top-level grader.
+When using lists, such as with a `ListGrader` or a `SingleListGrader`, you only need to provide an `answers` key to the top-level grader (the one that is specified in the `cfn` key).
 
 
 ## Passing a grader directly
 
-Because the `cfn` parameter of the `customresponse` tag is executed as python code, it is possible to skip the definition of the grader altogether, as the following example shows.
+Because the `cfn` parameter of the `customresponse` tag is executed as python code, it is possible to provide the definition of the grader in-line, as the following example shows.
 
 ```XML
 <problem>
@@ -114,4 +115,4 @@ from mitxgraders import *
 </problem>
 ```
 
-One must be careful to make sure that quotation marks are properly escaped if using this method.
+We want to stress the simplicity of this example compared to implementing the same problem using standard edX problem types! This method of defining a grader is very handy for simple grader constructions such as this one. For more complex graders, we recommend the previous style. One must be careful to make sure that quotation marks `'` and `"` do not conflict if using the in-line method.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,5 @@
+# Frequently Asked Questions (FAQs)
+
+- Does the grading library work with multiple choice/checkbox/dropdown lists?
+
+Unfortunately, no. Those problem types cannot be used in a `customresponse` problem, so we can't grade them with a python grader.

--- a/docs/graders.md
+++ b/docs/graders.md
@@ -1,0 +1,101 @@
+# Introduction to Graders
+
+Graders are implemented as python classes. All grading classes are instantiated by calling them. Options can be provided using keyword arguments as
+```python
+grader = FakeGradingClass(option_1=value_1, option_2=value2)
+# FakeGradingClass is not real! It's just a placeholder.
+```
+or with a configuration dictionary:
+```python
+config = {'option_1': value_1, 'option_2': value_2}
+grader = FakeGradingClass(config)
+```
+Passing the configuration as a dictionary can be useful if you are using the same configuration for multiple problems. However, you cannot 'mix and match' these two options: if a configuration dictionary is supplied, any keyword arguments are ignored.
+
+Most configuration options are specific to their grading classes. For example, `FormulaGrader` has a `variables` configuration key, but `NumericalGrader` does not.
+
+A few configuration options are available to all grading classes.
+
+## Debugging
+
+Every grading class has a debug option. By default, `debug=False`. To receive debug information from a given grader, specify `debug=True`. Some graders will provide more debug information than others. Debug information can be used by authors to check to make sure that the graders are behaving as expected, but shouldn't be made available to students.
+
+```python
+grader = FakeGradingClass(debug=True)
+```
+
+## Validation
+
+Every grading class has a `suppress_warnings` key.
+
+The options passed to a grading class undergo extensive validation and graders will giver error messages if instantiated with invalid options.
+
+A few error messages serve only as warnings. For example, if you attempt to configure a `FormulaGrader` with `pi` as a variable, you will receive a warning:
+
+```pycon
+>>> from mitxgraders import *
+>>> try:
+...     grader = FormulaGrader(variables=['pi'])
+... except ConfigError as error:
+...     print(error)
+Warning: 'variables' contains entries 'pi' which will override default values. If you intend to override defaults, you may suppress this warning by adding 'suppress_warnings=True' to the grader configuration.
+
+```
+
+As the warning message says, if you really want to override the default value of `pi` (not recommended!) then you can suppress this warning by setting `suppress_warnings=True`.
+
+```pycon
+>>> from mitxgraders import *
+>>> grader = FormulaGrader(variables=['pi'], suppress_warnings=True)
+
+```
+
+## Attempt-Based Partial Credit
+
+It is possible to pass a student's attempt number to a grader by explicitly requesting that edX do so in a `customresponse` tag as follows.
+
+```XML
+<customresponse cfn="grader" expect="answer" cfn_extra_args="attempt">
+```
+
+Once this is done, you can enable attempt-based partial credit for your graders. The syntax is as follows.
+
+```python
+grader = FakeGradingClass(
+    attempt_based_credit=True,     # default False
+    decrease_credit_after=1,       # default 1
+    minimum_credit=0.2,            # default 0.2
+    decrease_credit_steps=4,       # default 4
+    attempt_based_credit_msg=True  # default True
+)
+```
+
+Attempt-based partial credit is turned on by setting `attempt_based_credit=True`. When it is turned on, the first attempt a student makes will be eligible for full credit, while subsequent attempts may have a decreasing maximum score.
+
+- The maximum score begins to decrease after the attempt specified in `decrease_credit_after`. By default, all attempts after the first will have decreasing credit.
+
+- The credit decreases linearly to `minimum_credit`.
+
+- The number of attempts the credit decreases for is specified in `decrease_credit_steps`. So, using the defaults, attempts 1, 2, 3, 4, 5, and 6 are eligible for maximum credits of 1, 0.8, 0.6, 0.4, 0.2 and 0.2, respectively.
+
+- If a student's credit has been decreased from the maximum by attempt-based partial credit, the student can be provided with a message informing them of the maximum possible credit at that attempt number. This is controlled by the `attempt_based_credit_msg` setting. We recommend that this setting be left on, as it will likely lead to confusion otherwise.
+
+When using nested graders, these settings need only be applied to the grader that is provided to edX in the `cfn` key. These settings can be set on a course-wide basis through the use of [plugins](plugins.md).
+
+Note that if attempt-based partial credit is turned on but the `cfn_extra_args="attempt"` entry is missing from the `customresponse` tag, an error message results.
+
+
+## Option Listing
+
+Here is the full list of options specific to all graders.
+```python
+grader = AbstractGrader(
+    debug=bool,  # default False
+    wrong_msg=str,  # default ''
+    attempt_based_credit=bool,  # default False
+    decrease_credit_after=int,  # default 1
+    minimum_credit=float,  # default 0.2
+    decrease_credit_steps=int,  # default 4
+    attempt_based_credit_msg=bool,  # default True
+)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,14 +12,17 @@ The `mitxgraders` Python library provides a number of configurable Python classe
 
 Use MITxGraders because it:
 
- - has many capabilities beyond the standard edX options
- - is highly configuration but with *sensible defaults*
- - provides useful error messages
-      - to students (when submitting answers &mdash; for example, formula parsing errors)
-      - to problem authors (when configuring a grader)
- - is reliable (extensively tested)
- - is open source (BSD-3 license, [our Github repo](https://github.com/mitodl/mitx-grading-library))
- - has an [excellent example edX course](https://edge.edx.org/courses/course-v1:MITx+grading-library+examples/)
+- has many capabilities beyond the standard edX options
+- is highly configurable but with *sensible defaults*
+- provides useful error messages
+    - to students (when submitting answers &mdash; for example, formula parsing errors)
+    - to problem authors (when configuring a grader)
+- is reliable (extensively tested)
+- is open source (BSD-3 license, [our Github repo](https://github.com/mitodl/mitx-grading-library))
+- has an [excellent example edX course](https://edge.edx.org/courses/course-v1:MITx+grading-library+examples/)
+- is ready for the future of edX by being compatible with python 2 and 3
+- is actively maintained
+
 
 ## Two Typical Examples
 
@@ -28,11 +31,11 @@ Typical usage in an edX course looks like:
 <!-- First Example -->
 <problem>
 <script type="loncapa/python">
-from mitxgraders import FormulaGrader, RandomFunction
+from mitxgraders import *
 grader = FormulaGrader(
     variables=["x"],
     # allows students to use generic functions f and f' in their input
-    user_functions={ "f": RandomFunction(), "f'":RandomFunction() }
+    user_functions={"f": RandomFunction(), "f'": RandomFunction()}
 )
 </script>
 
@@ -51,15 +54,14 @@ The next example grader would grade an unordered list of mathematical expression
 ```XML
 <problem>
 <script type="loncapa/python">
-from mitxgraders import FormulaGrader, ListGrader
-grader = FormulaGrader(
+from mitxgraders import *
+grader = ListGrader(
     answers=['x-2', 'x+2'],
-    ordered=False,
     subgraders=FormulaGrader(variables=['x'])
 )
 </script>
 
-  <p>What are the linear factors of \((x^2 - 4)\)?</p>
+  <p>What are the linear factors of \((x^2 - 4)\)? Enter your answers in any order.</p>
   <customresponse cfn="grader">
     <!-- correct_answer is shown to student when they press [Show Answer].
          Its value is not used for grading purposes -->
@@ -72,9 +74,10 @@ grader = FormulaGrader(
 
 ## Loading in edX
 
-Download [python_lib.zip](python_lib.zip) and place it in your static folder (XML workflow) or upload it as a file asset (Studio workflow). If you already have a python_lib.zip, you'll need to merge ours with yours and re-zip. If you want to use our AsciiMath renderer definitions, place the [MjxPrep.js](MjxPrep.js) file in your static folder (XML) or upload the file to your course assets (Studio).
+Download [python_lib.zip](https://github.com/mitodl/mitx-grading-library/raw/master/python_lib.zip) and place it in your static folder (XML workflow) or upload it as a file asset (Studio workflow). If you already have a python_lib.zip, you'll need to merge ours with yours and re-zip. If you want to use our AsciiMath renderer definitions (if you have math problems, you'll really want this!), place the [MJxPrep.js](https://raw.githubusercontent.com/mitodl/mitx-grading-library/master/MJxPrep.js) file in your static folder (XML) or upload the file to your course assets (Studio).
 
 The basic idea of this library is that it contains a number of classes that can be used as the check function for an edX custom response problem. Different classes of grader are used for different inputs. We begin by presenting a brief overview on how the grading classes are used in general.
+
 
 ## Grading Classes
 
@@ -83,70 +86,34 @@ Grading classes generally fall into two categories: single-input graders and mul
 **Single-input graders** grade a single input. All single-input graders are built on a framework we call an `ItemGrader`. We recommend understanding how `ItemGrader`s work before diving into more specifics.
 
 - [ItemGrader](item_grader.md)
-    - [StringGrader](string_grader.md) for grading simple strings of text
-    - [FormulaGrader](grading_math/formula_grader.md) for grading scalar formulas
+    - [StringGrader](string_grader.md) for grading text input (includes pattern matching)
+    - [FormulaGrader](grading_math/formula_grader.md) for grading general formulas
     - [NumericalGrader](grading_math/numerical_grader.md) for grading numbers
     - [MatrixGrader](grading_math/matrix_grader/matrix_grader.md) for grading formulas with vectors and matrices
-    - [SingleListGrader](grading_lists/single_list_grader.md) for grading a delimiter-separated (default: comma-separated) list of inputs in a single response box
+    - [SingleListGrader](grading_lists/single_list_grader.md) for grading a delimited (default: comma-separated) list of inputs in a single response box
 
 **Multi-input graders** are for grading multiple input boxes at once. They are composed of single-input graders working in concert, handled by the general `ListGrader` class. At this stage, `ListGrader` is the only multi-input grader included in the library, although plugins can be used to construct further examples.
 
 - [ListGrader](grading_lists/list_grader.md) for grading a list of inputs. Examples:
-    - grade an ordered list of strings
+    - grade an ordered list of text inputs
     - grade an unordered list of mathematical expressions
     - grade a list of eigenvalue-eigenvector pairs
 
-## Using Grading Classes
+**Specialized graders** are used to grade very specific situations. The only specialized grader we presently have is `IntegralGrader`.
 
-All grading classes are instantiated by calling them. Options can be provided using keyword arguments as
-```python
-grader = FakeGradingClass(option_1=value_1, option_2=value2)
-# FakeGradingClass is not real! It's just a placeholder
-```
-or with a configuration dictionary:
-```python
-config = {'option_1': value_1, 'option_2': value_2}
-grader = FakeGradingClass(config)
-```
-Passing the configuration as a dictionary can be useful if you are using the same configuration for multiple problems. However, you cannot 'mix and match' these two options: if a configuration dictionary is supplied, any keyword arguments are ignored.
-
-Most configuration options are specific to their grading classes. For example, `FormulaGrader` has a `variables` configuration key, but `NumericalGrader` does not.
-
-A few configuration options are accessible to all grading classes.
-
-### Debugging
-
-Every grading class has a debug option. By default, `debug=False`. To receive debug information from a given grader, specify `debug=True`. Some graders will provide more debug information than others. Debug information can be used by authors to check to make sure that the graders are behaving as expected, but shouldn't be made available to students.
-
-```python
-grader = GradingClass(debug=True)
-```
-
-### Validation
-
-Every grading class has a `suppress_warnings` key.
-
-The options passed to a grading class undergo extensive validation and graders will throw errors if instantiated with invalid options.
-
-A few error messages serve only as warnings. For example, if you attempt to configure a `FormulaGrader` with `pi` as a variable, you will receive a warning:
-
-```pycon
->>> from mitxgraders import *
->>> try:
-...     grader = FormulaGrader(variables=['pi'])
-... except ConfigError as error:
-...     print(error)
-Warning: 'variables' contains entries 'pi' which will override default values. If you intend to override defaults, you may suppress this warning by adding 'suppress_warnings=True' to the grader configuration.
-
-```
-
-As the warning message says, if you really want to override the default value of `'pi'` (not recommended!) then you can suppress this warning by setting `suppress_warnings=True`.
+- [IntegralGrader](grading_math/integral_grader.md) for grading the construction of integrals.
 
 
-## Plugins
+## Questions? Bugs? Issues? Suggestions?
 
-Any `.py` file stored in the `plugins` folder will be automatically loaded. All variables in the `__all__` list will be made available when doing `from mitxgraders import *`. See `template.py` for an example.
+Please contact us by making an issue on [github](https://github.com/mitodl/mitx-grading-library).
 
-You can define custom grading classes in your plugin. To learn how this works, we recommend copying the code from `stringgrader.py`, renaming the class, and building a simple plugin based on `StringGrader`.
 
-We are happy to include user-contributed plugins in the repository for this library. If you have built a plugin that you would like to see combined into this library, please contact the authors through [github](https://github.com/mitodl/mitx-grading-library). We are also willing to consider incorporating good plugins into the library itself.
+## What should I read next?
+
+- If you haven't already done so, we recommend looking at our [example course](https://edge.edx.org/courses/course-v1:MITx+grading-library+examples/) to get an idea of the type of things that the library is capable of.
+- It's probably a good idea to start by looking at how to [invoke the grading library in edX](edx.md).
+- Next, we recommend looking at the [Introduction to Graders](graders.md) and the overview of [ItemGraders](item_grader.md).
+- After that, choose a grader that you're interested in, look at [source code for examples for that grader](https://github.com/mitodl/mitx-grading-library/tree/master/course/problem), and read up on the relevant documentation.
+
+Enjoy!

--- a/docs/item_grader.md
+++ b/docs/item_grader.md
@@ -3,10 +3,12 @@
 When an individual input needs to be graded, it is graded by an `ItemGrader`. All `ItemGrader`s work by specifying answers and their corresponding points/messages, as well as an optional message for wrong answers. In these examples, we use `StringGrader` as an example of how to use a generic `ItemGrader`. You cannot use a generic `ItemGrader` by itself.
 
 ```pycon
+>>> from mitxgraders import *
 >>> grader = StringGrader(
 ...     answers='cat',
 ...     wrong_msg='Try again!'
 ... )
+
 ```
 
 The grader is set up to grade an answer of `cat` as correct, and includes a message that is presented to students if they get the answer wrong. One could pass `grader` in as the `cfn` key for a `customresponse` tag. The following code demonstrates what happens when the grader is called using python (for example, inside a python console). Note that this is only for demonstrating the behavior of the grader, and is not required in order to use the library in edX.
@@ -16,6 +18,7 @@ The grader is set up to grade an answer of `cat` as correct, and includes a mess
 True
 >>> grader(None, 'dog') == {'grade_decimal': 0, 'msg': 'Try again!', 'ok': False}
 True
+
 ```
 
 You will often see this type of demonstration in this documentation. It serves both to demonstrate how the grader works and to ensure that our examples are always syntactically correct, as these code blocks form part of our documentation testing.
@@ -40,6 +43,7 @@ For all `ItemGrader`s, the `answers` key can be used to specify correct answers,
 True
 >>> grader(None, 'cat') == {'grade_decimal': 0, 'msg': 'Try again!', 'ok': False}
 True
+
 ```
 
 - A single `'expect'` value: can be used to specify the correct answer. For example,
@@ -51,10 +55,11 @@ True
 ...     # answers={'expect': 'zebra', 'msg': '', 'grade_decimal': 1}
 ...     wrong_msg='Try again!'
 ... )
->>> grader(None, 'zebra') == {'grade_decimal': 1, 'msg': 'Yay!', 'ok': True}
+>>> grader(None, 'zebra') == {'grade_decimal': 1, 'msg': '', 'ok': True}
 True
 >>> grader(None, 'cat') == {'grade_decimal': 0, 'msg': 'Try again!', 'ok': False}
 True
+
 ```
 
   Again, most `ItemGrader`s use strings to store `'expect'` values.
@@ -85,6 +90,7 @@ True
 True
 >>> grader(None, 'cat') == {'grade_decimal': 0, 'msg': 'Try again!', 'ok': False}
 True
+
 ```
 
 Internally, the `ItemGrader` converts the answers entry into a tuple of dictionaries. When grading, it asks the specific grading class to grade the response against each possible answer, and selects the best outcome for the student.

--- a/docs/item_grader.md
+++ b/docs/item_grader.md
@@ -1,74 +1,105 @@
 # ItemGrader
 
-When an individual input needs to be graded, it is graded by an item grader. All item graders work by specifying answers and their corresponding points/messages, as well as an optional message for wrong answers. In these examples, we use `StringGrader` as an example of how to use a generic ItemGrader. You cannot use a generic `ItemGrader` by itself.
+When an individual input needs to be graded, it is graded by an `ItemGrader`. All `ItemGrader`s work by specifying answers and their corresponding points/messages, as well as an optional message for wrong answers. In these examples, we use `StringGrader` as an example of how to use a generic `ItemGrader`. You cannot use a generic `ItemGrader` by itself.
 
-```python
-grader = StringGrader(
-    answers='cat',
-    wrong_msg='Try again!'
-)
+```pycon
+>>> grader = StringGrader(
+...     answers='cat',
+...     wrong_msg='Try again!'
+... )
 ```
 
-The `answers` key can be used to specify correct answers, specific feedback messages, and to assign partial credit. It accepts a few formats:
+The grader is set up to grade an answer of `cat` as correct, and includes a message that is presented to students if they get the answer wrong. One could pass `grader` in as the `cfn` key for a `customresponse` tag. The following code demonstrates what happens when the grader is called using python (for example, inside a python console). Note that this is only for demonstrating the behavior of the grader, and is not required in order to use the library in edX.
+
+```pycon
+>>> grader(None, 'cat') == {'grade_decimal': 1, 'msg': '', 'ok': True}
+True
+>>> grader(None, 'dog') == {'grade_decimal': 0, 'msg': 'Try again!', 'ok': False}
+True
+```
+
+You will often see this type of demonstration in this documentation. It serves both to demonstrate how the grader works and to ensure that our examples are always syntactically correct, as these code blocks form part of our documentation testing.
+
+
+## Specifying Answers
+
+For all `ItemGrader`s, the `answers` key can be used to specify correct answers, specific feedback messages, and to assign partial credit. It accepts a few formats:
 
 - A single dictionary can be used to specify an answer, feedback, correctness, and partial credit. The dictionary keys are:
 
-    - `'expect'` (required): compared against student answer. Most ItemGraders use strings to specify the `'expect'` value.
-    - `'grade_decimal'` (optional, a number between `0` and `1`): The credit associated with this answer; default value is `1`.
-    - `'ok'` (optional, `True`, `False`, or `'partial'`): The answer's correctness; determines icon used by edX. The default value is inferred from `grade_decimal`.
-    - `'msg'` (optional, string): A feedback message associated with this answer.
+    - `'expect'` (required): compared against student answer. Most `ItemGrader`s use strings to specify the `'expect'` value.
+    - `'grade_decimal'` (optional, a number between `0` and `1` inclusive): The credit associated with this answer (default `1`).
+    - `'msg'` (optional, string): An optional feedback message associated with this answer (default `''`).
 
-```python
-grader = StringGrader(
-    answers={'expect': 'zebra', 'ok': True, 'grade_decimal': 1, 'msg': 'Yay!'},
-    wrong_msg='Try again!'
-)
+```pycon
+>>> grader = StringGrader(
+...     answers={'expect': 'zebra', 'grade_decimal': 1, 'msg': 'Yay!'},
+...     wrong_msg='Try again!'
+... )
+>>> grader(None, 'zebra') == {'grade_decimal': 1, 'msg': 'Yay!', 'ok': True}
+True
+>>> grader(None, 'cat') == {'grade_decimal': 0, 'msg': 'Try again!', 'ok': False}
+True
 ```
 
 - A single `'expect'` value: can be used to specify the correct answer. For example,
 
-```python
-grader = StringGrader(
-    answers='cat',
-    # Equivalent to:
-    # answers={'expect': 'cat', 'msg': '', 'grade_decimal': 1, 'ok': True}
-    wrong_msg='Try again!'
-)
+```pycon
+>>> grader = StringGrader(
+...     answers='zebra',
+...     # Equivalent to:
+...     # answers={'expect': 'zebra', 'msg': '', 'grade_decimal': 1}
+...     wrong_msg='Try again!'
+... )
+>>> grader(None, 'zebra') == {'grade_decimal': 1, 'msg': 'Yay!', 'ok': True}
+True
+>>> grader(None, 'cat') == {'grade_decimal': 0, 'msg': 'Try again!', 'ok': False}
+True
 ```
 
-  Again, most ItemGraders use strings to store `'expect'` values.
+  Again, most `ItemGrader`s use strings to store `'expect'` values.
 
-- A tuple of dictionaries or strings:
+- A tuple of the afore-mentioned dictionaries/strings, which specifies multiple possible answers:
 
-```python
-grader = StringGrader(
-    answers=(
-        # the correct answer
-        'wolf',
-        # an alternative correct answer
-        'canis lupus',
-        # a partially correct answer
-        {'expect': 'dog', 'grade_decimal': 0.5, 'msg': 'No, not dog!'},
-        # a wrong answer with specific feedback
-        {'expect': 'unicorn', 'grade_decimal': 0, 'msg': 'No, not unicorn!'}
-    ),
-    wrong_msg='Try again!'
-)
+```pycon
+>>> grader = StringGrader(
+...     answers=(
+...         # the correct answer
+...         'wolf',
+...         # an alternative correct answer
+...         'canis lupus',
+...         # a partially correct answer
+...         {'expect': 'dog', 'grade_decimal': 0.5, 'msg': 'No, not dog!'},
+...         # a wrong answer with specific feedback
+...         {'expect': 'unicorn', 'grade_decimal': 0, 'msg': 'No, not unicorn!'}
+...     ),
+...     wrong_msg='Try again!'
+... )
+>>> grader(None, 'wolf') == {'grade_decimal': 1, 'msg': '', 'ok': True}
+True
+>>> grader(None, 'canis lupus') == {'grade_decimal': 1, 'msg': '', 'ok': True}
+True
+>>> grader(None, 'dog') == {'grade_decimal': 0.5, 'msg': 'No, not dog!', 'ok': 'partial'}
+True
+>>> grader(None, 'unicorn') == {'grade_decimal': 0, 'msg': 'No, not unicorn!', 'ok': False}
+True
+>>> grader(None, 'cat') == {'grade_decimal': 0, 'msg': 'Try again!', 'ok': False}
+True
 ```
 
 Internally, the `ItemGrader` converts the answers entry into a tuple of dictionaries. When grading, it asks the specific grading class to grade the response against each possible answer, and selects the best outcome for the student.
 
 The `wrong_msg` is only displayed if the score is zero and there are no other messages.
 
-If no `answers` key is provided, the grader reads from the `expect` or `answer` parameter of the `customresponse` tag (see below). However, note that when using a `ListGrader` or a `SingleListGrader`, the `answers` key is required.
+If no `answers` key is provided, the grader reads from the `expect` or `answer` parameter of the `customresponse` tag (see [edX Syntax](edx.md)). Note that when using a `ListGrader`, the `answers` key is required.
 
 
 ## Option Listing
 
-Here is the full list of options specific to an `ItemGrader`.
+Here is the full list of options specific to `ItemGrader`s.
 ```python
 grader = ItemGrader(
-    answers=answer or tuple of answers,
-    wrong_msg=str (default '')
+    answers=(str, dict, (str, dict)),
+    wrong_msg=str,  # default ''
 )
 ```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,24 @@
+# Plugins
+
+Plugins are an advanced feature of the library that allows users to construct their own custom-built graders, built on top of the infrastructure of the library. They can also be used to allow for straightforward code re-use, and to override library defaults on a course-wide basis.
+
+Any `.py` file stored in the `mitxgraders/plugins` folder will be automatically loaded. All variables in the `__all__` list will be made available when doing `from mitxgraders import *`. See `template.py` for an example.
+
+You can define custom grading classes in your plugin. To learn how this works, we recommend copying the code from `stringgrader.py`, renaming the class, and building a simple plugin based on `StringGrader`.
+
+We are happy to include user-contributed plugins in the repository for this library. If you have built a plugin that you would like to see combined into this library, please contact the authors through [github](https://github.com/mitodl/mitx-grading-library). We are also willing to consider incorporating good plugins into the library itself.
+
+
+## Overriding Library Defaults
+
+Library defaults for any grading class can be specified by constructing the desired dictionary of defaults, and calling `register_defaults(dict)` on the class. For example, to specify that all `StringGrader`s should be case-insensitive by default, you can do the following.
+
+```pycon
+StringGrader.register_defaults({
+    'case_sensitive': False
+})
+```
+
+When this code is included in a file in the plugins folder, it automatically runs every time the library is loaded, leading to course-wide defaults. If for some reason you need to reset to the library defaults for a specific problem, you can call `clear_registered_defaults()` on the class in that problem.
+
+An example plugin has been provided for you in `defaults_sample.py`. The code in this plugin is commented out so that it doesn't change anything by default. If you are interested in overriding library defaults on a course-wide basis, we recommend copying this file to `defaults.py` and setting the desired defaults using the code templates provided. This is particularly useful if you wish to use attempt-based partial credit throughout your course.

--- a/docs/string_grader.md
+++ b/docs/string_grader.md
@@ -1,6 +1,6 @@
 # StringGrader
 
-The `StringGrader` class grades text inputs. It can perform comparisons to expected answers or patterns, and can also accept arbitrary input. It is the simplest grading class, both in code and in usage.
+The `StringGrader` class is an `ItemGrader` that grades text inputs. It can perform comparisons to expected answers or patterns, and can also accept arbitrary input. It is the simplest grading class, both in code and in usage.
 
 To use a `StringGrader` in its simplest form, simply pass in the set of answers you want to grade, as described in the [ItemGrader documentation](item_grader.md).
 
@@ -18,7 +18,7 @@ True
 
 ```
 
-This will accept the answer of `cat`, but not `CAT` or `Cat`, as grading is case-sensitive by default.
+This example will accept the answer of `cat`, but not `CAT` or `Cat`, as grading is case-sensitive by default.
 
 
 ## Cleaning Input
@@ -53,7 +53,7 @@ True
 
 ```
 
-Here, the answer is `two  spaces`, complete with two spaces. A students' answer of `two spaces` (with a single space) would be graded incorrect.
+Here, the answer is `two  spaces`, complete with two spaces (which may not render on a webpage). A student's answer of `two spaces` (with a single space) would be graded incorrect.
 
 Finally, you may have a situation where spaces are completely irrelevant (e.g., when grading a mathematical expression). To instruct the grader to completely ignore all spaces, set `strip_all=True`.
 
@@ -91,9 +91,9 @@ True
 This will accept `Cat`, `cat` and `CAT`. By default, `case_sensitive=True`.
 
 
-## Accepting anything (within reason!)
+## Accepting Anything
 
-Sometimes you may just want to accept anything that a student provides (possibly subject to conditions). This can be useful, for example, when asking for a free response to a prompt, and can be used in conjunction with validation (see below) to accept a variety of answers that satisfy a given pattern. To do this, set the `accept_any` flag, which will literally accept anything that is entered into the textbox.
+Sometimes you may just want to accept anything that a student provides (possibly subject to conditions). This can be useful, for example, when asking for a free response to a prompt, and can be used in conjunction with validation (see below) to accept a variety of answers that satisfy a given pattern. To do this, set the `accept_any` flag, which will cause the grader to literally accept anything that is entered into the textbox.
 
 ```pycon
 >>> grader = StringGrader(
@@ -146,35 +146,39 @@ True
 ...                               'msg': 'Your response is too short (2/3 words)',
 ...                               'ok': False}
 True
+>>> grader(None, '  a  b  c  d  ') == {'grade_decimal': 0,
+...                                    'msg': 'Your response is too short (7/10 characters)',
+...                                    'ok': False}
+True
 
 ```
 
-Note that punctuation doesn't break a word for the purpose of word counting, so `isn't word-counting fun?` will only count as three words. If `accept_nonempty` and `min_length` are both used, the more stringent requirement is the one that is used.
+Note that punctuation doesn't break a word for the purpose of word counting, so `isn't word-counting fun?` will only count as three words. If `accept_nonempty` and `min_length` are both used, the longer requirement is the one that is used.
 
 When a student's answer is rejected because it doesn't meet the minimum requirements, there are three types of feedback that you can provide, controlled by the `explain_minimums` flag:
 
-* The student receives an error message describing how many words/characters they have, compared to how many are required. This does not consume an attempt (`explain_minimums='err'`, default)
-* The student is graded incorrect, but a message is provided describing how many words/characters they have, compared to how many are required. This does consume an attempt (`explain_minimums='msg'`)
-* The student is graded incorrect, and no explanation is given. This does consume an attempt (`explain_minimums=None`)
+* The student receives an error message describing how many words/characters they have, compared to how many are required. This does not consume an attempt (`explain_minimums='err'`, default).
+* The student is graded incorrect, but a message is provided describing how many words/characters they have, compared to how many are required. This consumes an attempt (`explain_minimums='msg'`).
+* The student is graded incorrect, and no explanation is given. This consumes an attempt (`explain_minimums=None`).
 
-The flags `min_length`, `min_words` and `explain_minimums` are all ignored if not using `accept_any` or `accept_nonempty`.
+The settings `min_length`, `min_words` and `explain_minimums` are all ignored if not using `accept_any` or `accept_nonempty`.
 
 
 ## Validating Input
 
 Sometimes, you may want to validate student input against a pattern. This can be useful if the student response simply needs to follow a given pattern, or if you want to reject student responses that don't conform to the required format. Validation can be used both when comparing against an expected response, or when using `accept_any` (and variants).
 
-Validation is performed by constructing a python regular expressions (regex) pattern, stored in the `validation_pattern` flag (if you are unfamiliar with regular expressions, there are many excellent tutorials available online to get you started!). After input cleaning, the student input is checked against the pattern for a match. If no match is found, the desired response is returned. Expected answers are also checked against the pattern; if a possible answer does not conform to the pattern, then a `ConfigError` is raised.
+Validation is performed by constructing a python regular expressions (regex) pattern, stored in the `validation_pattern` flag (if you are unfamiliar with regular expressions, there are many excellent tutorials available online to get you started!). After input cleaning, the student input is checked against the pattern for a match. If no match is found, the desired response is returned. Expected answers are also checked against the pattern; if a possible answer does not conform to the pattern, then a configuration error results.
 
 When a response doesn't satisfy the given pattern, there are three types of feedback that you can provide, controlled by the `explain_validation` flag:
 
-* The student receives an error message. This does not consume an attempt (`explain_validation='err'`, default)
-* The student is graded incorrect, but receives a message. This does consume an attempt (`explain_validation='msg'`)
-* The student is graded incorrect, and no explanation is given. This does consume an attempt (`explain_validation=None`)
+* The student receives an error message. This does not consume an attempt (`explain_validation='err'`, default).
+* The student is graded incorrect, but receives a message. This consumes an attempt (`explain_validation='msg'`).
+* The student is graded incorrect, and no explanation is given. This consumes an attempt (`explain_validation=None`).
 
-In the first two cases, the message provided is given by the `invalid_msg` flag, which defaults to `Your input is not in the expected format`.
+In the first two cases, the message provided is given by the `invalid_msg` setting, which defaults to `Your input is not in the expected format`.
 
-Here is an example of using a validation pattern to accept inputs that look like chemical formulae for organic molecules. Note that anything that matches the pattern will be accepted.
+Here is an example of using a validation pattern to accept inputs that look like chemical formulae for organic molecules. Note that anything that matches the pattern will be graded correct.
 
 ```pycon
 >>> grader = StringGrader(
@@ -195,7 +199,7 @@ True
 
 ```
 
-Here, we use validation to ensure that the student input matches the desired format before comparing to the answer, and give the student an error message if their input doesn't match the specification.
+Below, we use validation to ensure that the student input matches the desired format before comparing to the answer, and give the student an error message if their input doesn't match the specification.
 
 ```pycon
 >>> grader = StringGrader(
@@ -210,6 +214,11 @@ True
 True
 >>> try:
 ...     grader(None, '(a)(2)')
+... except InvalidInput as error:
+...     print(error)
+Your input is not in the expected format
+>>> try:
+...     grader(None, '[1)(2)')
 ... except InvalidInput as error:
 ...     print(error)
 Your input is not in the expected format

--- a/mitxgraders/plugins/defaults_sample.py
+++ b/mitxgraders/plugins/defaults_sample.py
@@ -54,3 +54,10 @@ from mitxgraders.formulagrader.matrixgrader import MatrixGrader
 # MatrixGrader.register_defaults({
 #     'entry_partial_credit': 'partial'
 # })
+
+# You can also use this plug-in to make pre-built graders and functions available to
+# all your problems. You just need to include them in the __all__ list. For example:
+# my_grader = FormulaGrader(variables=['x', 'y'])
+# __all__ = ['my_grader']
+# Now, "from mitxgraders import *"" will make my_grader available to you in a problem
+# You can similarly define custom functions etc, in the same way.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,9 +6,10 @@ theme:
 pages:
   - Getting Started:
     - Overview: 'index.md'
+    - edX Syntax: 'edx.md'
+    - Introduction to Graders: 'graders.md'
     - ItemGrader: 'item_grader.md'
     - StringGrader: 'string_grader.md'
-    - edX Syntax: 'edx.md'
   - Grading Math:
     - FormulaGrader: 'grading_math/formula_grader.md'
     - NumericalGrader: 'grading_math/numerical_grader.md'
@@ -21,6 +22,8 @@ pages:
   - Grading Lists:
     - ListGrader: 'grading_lists/list_grader.md'
     - SingleListGrader: 'grading_lists/single_list_grader.md'
+  - Plugins: 'plugins.md'
+  - Frequently Asked Questions: 'faq.md'
   - Changelog: 'changelog.md'
 markdown_extensions:
     - toc:


### PR DESCRIPTION
This updates all documentation that is not in the `grading_lists` or `grading_math` subdirectories.