### PR TITLE
Fixing bug with LinearComparer with less than 3 samples

### DIFF
--- a/mitxgraders/comparers/linear_comparer.py
+++ b/mitxgraders/comparers/linear_comparer.py
@@ -5,6 +5,7 @@ from voluptuous import Schema, Required, Any, Range
 from mitxgraders.comparers.baseclasses import CorrelatedComparer
 from mitxgraders.helpers.calc.mathfuncs import is_nearly_zero
 from mitxgraders.helpers.validatorfuncs import text_string
+from mitxgraders.exceptions import ConfigError
 
 def get_linear_fit_error(x, y):
     """
@@ -183,6 +184,11 @@ class LinearComparer(CorrelatedComparer):
             scalar_expected = isinstance(expected_0, Number)
             shape = tuple() if scalar_expected else expected_0.shape
             utils.validate_shape(student_evals[0], shape)
+
+        # Raise an error if there is less than 3 samples
+        if len(student_evals) < 3:
+            msg = 'Cannot perform linear comparison with less than 3 samples'
+            raise ConfigError(msg)
 
         is_comparing_zero = self.check_comparing_zero(comparer_params_evals,
                                                       student_evals, utils.tolerance)

--- a/mitxgraders/formulagrader/formulagrader.py
+++ b/mitxgraders/formulagrader/formulagrader.py
@@ -431,6 +431,7 @@ class FormulaGrader(ItemGrader):
     default_variables = DEFAULT_VARIABLES.copy()
     default_suffixes = DEFAULT_SUFFIXES.copy()
 
+    # Default comparer for FormulaGrader
     default_comparer = staticmethod(equality_comparer)
 
     @classmethod
@@ -962,6 +963,9 @@ class NumericalGrader(FormulaGrader):
 
         failable_evals (int): Will always be 0
     """
+
+    # Default comparer for NumericalGrader (independent of FormulaGrader)
+    default_comparer = staticmethod(equality_comparer)
 
     @property
     def schema_config(self):

--- a/mitxgraders/formulagrader/matrixgrader.py
+++ b/mitxgraders/formulagrader/matrixgrader.py
@@ -10,7 +10,7 @@ from collections import namedtuple
 import six
 from voluptuous import Required, Any, Range, All, Optional
 from mitxgraders.exceptions import InputTypeError
-from mitxgraders.comparers import MatrixEntryComparer
+from mitxgraders.comparers import MatrixEntryComparer, equality_comparer
 from mitxgraders.formulagrader.formulagrader import FormulaGrader
 from mitxgraders.helpers.validatorfuncs import NonNegative, Nullable, text_string
 from mitxgraders.helpers.calc import MathArray, within_tolerance, identity
@@ -72,6 +72,9 @@ class MatrixGrader(FormulaGrader):
         that MatrixGrader instance with the given key values. If neither key is
         provided, equality_comparer is used.
     """
+
+    # Default comparer for MatrixGrader (independent of FormulaGrader)
+    default_comparer = staticmethod(equality_comparer)
 
     # merge_dicts does not mutate the originals
     default_functions = merge_dicts(FormulaGrader.default_functions,

--- a/tests/comparers/test_linear_comparer.py
+++ b/tests/comparers/test_linear_comparer.py
@@ -1,5 +1,7 @@
-from mitxgraders import FormulaGrader, MatrixGrader, RealMatrices
+from pytest import raises
+from mitxgraders import FormulaGrader, MatrixGrader, RealMatrices, NumericalGrader
 from mitxgraders.comparers import LinearComparer
+from mitxgraders.exceptions import ConfigError
 
 def test_linear_comparer_default_modes():
     grader = FormulaGrader(
@@ -107,3 +109,15 @@ def test_works_with_matrixgrader():
     assert grader(None, '3*x*A*B^2 + 5*[[1, 1], [1, 1]]')['grade_decimal'] == 0.2
     assert grader(None, 'x*A*B^2 + x*[[1, 1], [1, 1]]')['grade_decimal'] == 0
     assert grader(None, '0*A')['grade_decimal'] == 0
+
+def test_linear_too_few_comparisons():
+    FormulaGrader.set_default_comparer(LinearComparer())
+    grader = FormulaGrader(samples=2)
+    with raises(ConfigError, match='Cannot perform linear comparison with less than 3 samples'):
+        grader('1.5', '1.5')
+
+    # Ensure that NumericalGrader does not use the same default comparer as FormulaGrader
+    grader = NumericalGrader()
+    assert grader('1.5', '1.5')['ok']
+
+    FormulaGrader.reset_default_comparer()


### PR DESCRIPTION
Caught a little bug in LinearComparer when writing documentation. We need to have at least 3 samples for the comparison to be meaningful!

In particular, NumericalGrader/MatrixGrader/FormulaGrader all shared the same default grader, if it was set on FormulaGrader. This decouples everything.