### PR TITLE
Restricting mkdocs-cinder version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pytest-cov==2.7.1
 
 # For documentation
 mkdocs==0.17.5
-mkdocs-cinder
+mkdocs-cinder==0.11.0
 
 # For uploading to edge
 requests

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -10,7 +10,7 @@ pytest-cov==2.7.1
 
 # For documentation
 mkdocs==0.17.5
-mkdocs-cinder
+mkdocs-cinder==0.11.0
 
 # For uploading to edge
 requests


### PR DESCRIPTION
I ran into this problem after reinstalling my virtual env: the mkdocs-cinder theme had been updated. I've forced mkdocs-cinder to be an old version (they're up to 0.17 now), but we should probably update mkdocs and mkdocs-cinder to latest versions at some point.