### PR TITLE
Fixing issue with MatrixGrader voluptuous schema

### DIFF
--- a/mitxgraders/comparers/comparers.py
+++ b/mitxgraders/comparers/comparers.py
@@ -181,7 +181,7 @@ class MatrixEntryComparer(CorrelatedComparer):
 
     default_msg = "Some array entries are incorrect, marked below:\n{error_locations}"
     schema_config = EqualityComparer.schema_config.extend({
-        Required('entry_partial_credit', default=0): Any(All(Number, Range(0, 1)), 'proportional'),
+        Required('entry_partial_credit', default=0): Any(All(float, Range(0, 1)), 0, 1, 'proportional'),
         Required('entry_partial_msg', default=default_msg): text_string
     })
 


### PR DESCRIPTION
The schema `Any(All(Number, Range(0, 1)), 'proportional')` allows `True` as an input, which evaluates to 1. This caught me out when making an example - it should complain if you give it `True`, when you probably mean `'proportional'` instead.