### PR TITLE
Coerce all inputs to unicode

### DIFF
--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -161,7 +161,7 @@ def test_fg_tolerance():
     assert not grader(None, '10.000001')['ok']
 
     expect = (r"Cannot have a negative percentage for dictionary value @ "
-              r"data\['tolerance'\]. Got '-1%'")
+              r"data\[u?'tolerance'\]. Got u?'-1%'")
     with raises(Error, match=expect):
         FormulaGrader(answers="10", tolerance="-1%")
 
@@ -227,7 +227,7 @@ def test_fg_userfunction():
         grader(None, "that'sbad(1)")
 
     expect = (r"1 is not a valid key, must be of type string for dictionary "
-              r"value @ data\['user_functions'\]. Got {{1: <ufunc 'tan'>}}").format(
+              r"value @ data\[u?'user_functions'\]. Got {{1: <ufunc 'tan'>}}").format(
               str_type=str)
     with raises(Error, match=expect):
         FormulaGrader(
@@ -244,7 +244,7 @@ def test_fg_userconstants():
     assert grader(None, "hello")['ok']
 
     expect = (r"1 is not a valid key, must be of type string for dictionary "
-              r"value @ data\['user_constants'\]. Got {1: 5}")
+              r"value @ data\[u?'user_constants'\]. Got {1: 5}")
     with raises(Error, match=expect):
         FormulaGrader(
             answers="1",
@@ -374,7 +374,7 @@ def test_fg_sampling():
     assert isinstance(grader.config["sample_from"]['z'], RealInterval)
     assert isinstance(grader.config["sample_from"]['w'], RealInterval)
 
-    with raises(MultipleInvalid, match=r"extra keys not allowed @ data\['w'\]"):
+    with raises(MultipleInvalid, match=r"extra keys not allowed @ data\[u?'w'\]"):
         grader = FormulaGrader(variables=['x'], sample_from={'w': 2})
 
     grader = FormulaGrader(
@@ -470,7 +470,7 @@ def test_fg_config_expect():
 
     # If trying to use comparer, a detailed validation error is raised
     expect = ("to have 3 arguments, instead it has 2 for dictionary value @ "
-              r"data\['answers'\]\[0\]\[u?'expect'\]\['comparer'\]")
+              r"data\[u?'answers'\]\[0\]\[u?'expect'\]\[u?'comparer'\]")
     with raises(Error, match=expect):
         FormulaGrader(
             answers={
@@ -658,14 +658,14 @@ def test_fg_evals_numbered_variables_in_siblings():
 
 def test_ng_config():
     """Test that the NumericalGrader config bars unwanted entries"""
-    expect = r"not a valid value for dictionary value @ data\['failable_evals'\]. Got 1"
+    expect = r"not a valid value for dictionary value @ data\[u?'failable_evals'\]. Got 1"
     with raises(Error, match=expect):
         NumericalGrader(
             answers="1",
             failable_evals=1
         )
 
-    expect = r"not a valid value for dictionary value @ data\['samples'\]. Got 2"
+    expect = r"not a valid value for dictionary value @ data\[u?'samples'\]. Got 2"
     with raises(Error, match=expect):
         NumericalGrader(
             answers="1",
@@ -673,14 +673,14 @@ def test_ng_config():
         )
 
     expect = (r"length of value must be at most 0 for dictionary value "
-              r"@ data\['variables'\]. Got \['x'\]")
+              r"@ data\[u?'variables'\]. Got \[u?'x'\]")
     with raises(Error, match=expect):
         NumericalGrader(
             answers="1",
             variables=["x"]
         )
 
-    expect = (r"extra keys not allowed @ data\['sample_from'\]\['x'\]. Got "
+    expect = (r"extra keys not allowed @ data\[u?'sample_from'\]\[u?'x'\]. Got "
               r"RealInterval\({u?'start': 1, u?'stop': 5}\)")
     with raises(Error, match=expect):
         NumericalGrader(
@@ -688,7 +688,7 @@ def test_ng_config():
             sample_from={"x": RealInterval()}
         )
 
-    expect = (r"not a valid value for dictionary value @ data\['user_functions'\]\[u?'f'\]. "
+    expect = (r"not a valid value for dictionary value @ data\[u?'user_functions'\]\[u?'f'\]. "
               r"Got RandomFunction")
     with raises(Error, match=expect):
         NumericalGrader(
@@ -696,7 +696,7 @@ def test_ng_config():
             user_functions={"f": RandomFunction()}
         )
 
-    expect = (r"not a valid value for dictionary value @ data\['user_functions'\]\[u?'f'\]. " + \
+    expect = (r"not a valid value for dictionary value @ data\[u?'user_functions'\]\[u?'f'\]. " + \
               r"Got \[<ufunc 'sin'>, <ufunc 'cos'>\]")
     with raises(Error, match=expect):
         NumericalGrader(

--- a/tests/formulagrader/test_integralgrader.py
+++ b/tests/formulagrader/test_integralgrader.py
@@ -26,7 +26,7 @@ def test_wrong_number_of_inputs_raises_error():
     )
     student_input = ['a', 'b']
     expected_message = (r"Expected 3 student inputs but found 2. "
-                        r"Inputs should  appear in order \['integrand', 'lower', 'upper'\].")
+                        r"Inputs should  appear in order \[u?'integrand', u?'lower', u?'upper'\].")
     with raises(ConfigError, match=expected_message):
         grader(None, student_input)
 

--- a/tests/helpers/calc/test_specify_domain.py
+++ b/tests/helpers/calc/test_specify_domain.py
@@ -111,7 +111,7 @@ def test_author_facing_decorator_raises_errors_with_invalid_config():
 
     match = (r"expected shape specification to be a positive integer, or a "
              r"list/tuple of positive integers \(min length 1, max length None\) @ "
-             r"data\['input_shapes'\]\[1\]. Got 0")
+             r"data\[u?'input_shapes'\]\[1\]. Got 0")
     with raises(Error, match=match):
         @specify_domain(input_shapes=[5, 0, [1, 2]])
         def g():


### PR DESCRIPTION
This coerces all arguments provided in `ObjectWithSchema` configs to unicode as necessary.

I don't know a good way to test that this works explicitly. Suggestions welcome.

Resolves #238 
