### PR TITLE
Adding extra error check to DependentSampler, fixing test coverage

### DIFF
--- a/mitxgraders/sampling.py
+++ b/mitxgraders/sampling.py
@@ -514,6 +514,23 @@ def gen_symbols_samples(symbols, samples, sample_from, functions, suffixes, cons
                     progress_made = True
 
             if not progress_made:
+                # Two possible causes
+                # 1: Depends on variables that are undefined
+                # Check for this first
+                all_depends = set()
+                for symbol, dependencies in list(unevaluated_dependents.items()):
+                    for item in dependencies:
+                        all_depends.add(item)
+                bad_items = []
+                for item in all_depends:
+                    if item not in unevaluated_dependents and item not in sample_dict:
+                        bad_items.append(item)
+                if bad_items:
+                    bad_symbols = ", ".join(sorted(bad_items))
+                    raise ConfigError("DependentSamplers depend on undefined quantities: " +
+                                      bad_symbols)
+
+                # 2: Circular dependencies
                 bad_symbols = ", ".join(sorted(unevaluated_dependents.keys()))
                 raise ConfigError("Circularly dependent DependentSamplers detected: " +
                                   bad_symbols)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -283,9 +283,15 @@ def test_dependent_sampler():
         gen_symbols_samples(symbols, samples, sample_from, funcs, suffs, consts)
 
     with raises(ConfigError, match=r"Formula error in dependent sampling formula: 1\+\(2"):
-        symbols = ["x"]
-        samples = 1
-        sample_from = {'x': DependentSampler(depends=[], formula="1+(2")}
+        DependentSampler(formula="1+(2")
+
+    symbols = ["x"]
+    samples = 1
+    sample_from = {'x': DependentSampler(formula="min(j, i)")}
+    with raises(ConfigError, match=r"Formula error in dependent sampling formula: min\(j, i\)"):
+        gen_symbols_samples(symbols, samples, sample_from, funcs, suffs, {'i': 1j, 'j': 1j})
+
+    with raises(ConfigError, match=r"DependentSamplers depend on undefined quantities: i, j"):
         gen_symbols_samples(symbols, samples, sample_from, funcs, suffs, consts)
 
     with raises(Exception, match="DependentSampler must be invoked with compute_sample."):


### PR DESCRIPTION
This adds an extra check to DependentSampler that we somehow missed previously. Also updates tests; should get us back to 100% coverage.