### PR TITLE
Generalizing attempt-based partial credit

### DIFF
--- a/course/problem/string6.xml
+++ b/course/problem/string6.xml
@@ -1,18 +1,29 @@
 <problem display_name="Attempt-Based Partial Credit" showanswer="always" weight="10" attempts="">
 
-<p>The library is capable of awarding reduced credit based on the attempt number for the student. This problem demonstrates how it works.</p>
+<p>The library is capable of awarding reduced credit based on the attempt number for the student. A python function converts the attempt number into a maximum amount of credit. We provide three built-in functions, but you're welcome to write your own.</p>
 
-<p>For a student's first attempt, they can be awarded maximum credit (10/10). A student's second attempt will be awarded at most 9/10. Each attempt will decrease by 1, to a minimum of 1/10. When credit is decreased because of attempt-based partial credit, students receive a message informing them of this by default.</p>
+<ul>
+  <li><code>LinearCredit</code>: Linearly decreasing credit to a minimum</li>
+  <li><code>GeometricCredit</code>: Maximum credit decreases by a factor for each attempt</li>
+  <li><code>ReciprocalCredit</code>: Maximum credit is 1 / attempt number</li>
+</ul>
+
+<p>In the below example, we use <code>LinearCredit</code> (but we modify it so that it "resets" every 10 attempts, so attempts 11, 21, 31, ... are treated like attempt 1 for the purpose of this demonstration, as you have no way to reset your attempts!).</p>
+
+<p>For a student's first attempt, they can be awarded maximum credit. A student's second attempt will be awarded at most 80%. Each attempt will decrease the maximum by 20%, to a minimum of 20%. When credit is decreased because of attempt-based partial credit, students receive a message informing them of this by default.</p>
 
 <p>The answer is "cat".</p>
 
 <script type="text/python" system_path="python_lib">
 from mitxgraders import *
-grader = StringGrader(
-    attempt_based_credit=True,
-    minimum_credit=0.1,    # Note: Number between 0 and 1
-    decrease_credit_steps=9
-)
+
+# This modification wraps the attempt number around at 10
+def modified_creditor(attempt):
+    newattempt = (attempt - 1) % 10 + 1
+    creditor = LinearCredit()
+    return creditor(newattempt)
+
+grader = StringGrader(attempt_based_credit=modified_creditor)
 </script>
 
 <!-- Note the extra argument to the customresponse tag! -->
@@ -21,9 +32,7 @@ grader = StringGrader(
 </customresponse>
 
 
-<p>Note that attempt-based partial credit applies to all graders; this is just an example of using it with a StringGrader. It's also possible to set course-wide defaults to apply attempt-based partial credit to all your questions through the use of a plugin (which we provide a sample for).</p>
-
-<p>We apologize that there is no mechanism by which you can reset your attempts for this question!</p>
+<p>Note that attempt-based partial credit applies to all graders; this is just an example of using it with a <code>StringGrader</code>. It's also possible to set course-wide defaults to apply attempt-based partial credit to all your questions through the use of a plugin (which we provide a sample for).</p>
 
 
 <p><a href="https://github.com/mitodl/mitx-grading-library/tree/master/course/problem/string6.xml" target="_blank">View source</a></p>

--- a/mitxgraders/__init__.py
+++ b/mitxgraders/__init__.py
@@ -31,6 +31,7 @@ from mitxgraders.matrixsampling import *
 from mitxgraders.exceptions import ConfigError, StudentFacingError, InvalidInput, MissingInput
 from mitxgraders.helpers.calc import *
 from mitxgraders.comparers import *
+from mitxgraders.attemptcredit import *
 
 def import_plugins():
     """Imports all plugins into the global namespace"""

--- a/mitxgraders/attemptcredit.py
+++ b/mitxgraders/attemptcredit.py
@@ -1,0 +1,163 @@
+"""
+attemptcredit.py
+
+This file contains various routines for assigning attempt-based partial credit.
+"""
+from __future__ import print_function, division, absolute_import, unicode_literals
+from voluptuous import Schema, Required, Any, Range, All
+from mitxgraders.baseclasses import ObjectWithSchema
+from mitxgraders.helpers.validatorfuncs import Positive
+
+__all__ = ['LinearCredit', 'GeometricCredit', 'ReciprocalCredit']
+
+class LinearCredit(ObjectWithSchema):
+    """
+    This class assigns credit based on a piecewise linear progression:
+    Constant - Linear Decrease - Constant
+
+    Credit
+    ^
+    |--
+    |  \
+    |   \
+    |    -----
+    |
+    +---------> Attempt number
+
+    Configuration:
+    ==============
+        decrease_credit_after (positive int): The last attempt number to award maximum
+            credit to (default 1)
+
+        minimum_credit (float between 0 and 1): The minimum amount of credit to be awarded
+            after using too many attempts (default 0.2)
+
+        decrease_credit_steps (positive int): How many attempts it takes to get to minimum
+            credit. So, if set to 1, after decrease_credit_after attempts, the next attempt
+            will receive minimum_credit. If set to 2, the next attempt will be halfway
+            between 1 and minimum_credit, and the attempt after that will be awarded
+            minimum_credit. (default 4)
+
+    Usage:
+    ======
+
+    >>> creditor = LinearCredit(decrease_credit_after=1, minimum_credit=0.2, decrease_credit_steps=4)
+    >>> creditor(1)
+    1
+    >>> creditor(2)
+    0.8
+    >>> creditor(3)
+    0.6
+    >>> creditor(4)
+    0.4
+    >>> creditor(5)
+    0.2
+    >>> creditor(6)
+    0.2
+
+    """
+    @property
+    def schema_config(self):
+        return Schema({
+            Required('decrease_credit_after', default=1): Positive(int),
+            Required('decrease_credit_steps', default=4): Positive(int),
+            Required('minimum_credit', default=0.2): Any(All(float, Range(0, 1)), 0, 1)
+        })
+
+    def __call__(self, attempt):
+        """
+        Return the credit associated with a given attempt number
+        """
+        if attempt == 1:
+            return 1
+
+        # How far past the point of decreasing credit are we?
+        steps = attempt - self.config['decrease_credit_after']
+        if steps <= 0:
+            return 1
+
+        # Compute the credit to be awarded
+        min_cred = self.config['minimum_credit']
+        decrease_steps = self.config['decrease_credit_steps']
+        if steps >= decrease_steps:
+            credit = min_cred
+        else:
+            # Linear interpolation
+            credit = 1 + (min_cred - 1) * steps / decrease_steps
+
+        return round(credit, 4)
+
+class GeometricCredit(ObjectWithSchema):
+    """
+    This class assigns credit based on a geometric progression:
+    1, x, x^2, etc.
+    x = 3/4 by default.
+
+    Configuration:
+    ==============
+        factor (float): Number between 0 and 1 inclusive that is the decreasing
+            factor for each attempt (default 0.75).
+
+    Usage:
+    ======
+
+    >>> creditor = GeometricCredit(factor=0.5)
+    >>> creditor(1)
+    1
+    >>> creditor(2)
+    0.5
+    >>> creditor(3)
+    0.25
+
+    """
+    @property
+    def schema_config(self):
+        return Schema({
+            Required('factor', default=0.75): Any(All(float, Range(0, 1)), 0, 1)
+        })
+
+    def __call__(self, attempt):
+        """
+        Return the credit associated with a given attempt number
+        """
+        if attempt == 1:
+            return 1
+        credit = self.config['factor'] ** (attempt - 1)
+        return round(credit, 4)
+
+class ReciprocalCredit(ObjectWithSchema):
+    """
+    This class assigns credit based on the reciprocal of attempt number.
+    1, 1/2, 1/3, etc.
+
+    Configuration:
+    ==============
+        None
+
+    Usage:
+    ======
+
+    >>> creditor = ReciprocalCredit()
+    >>> creditor(1)
+    1
+    >>> creditor(2)
+    0.5
+    >>> creditor(3)   # doctest: +ELLIPSIS
+    0.333...
+    >>> creditor(4)
+    0.25
+
+    """
+    @property
+    def schema_config(self):
+        # No configuration for this one!
+        return Schema({})
+
+    def __call__(self, attempt):
+        """
+        Return the credit associated with a given attempt number
+        """
+        if attempt == 1:
+            return 1
+        credit = 1.0 / attempt
+        return round(credit, 4)

--- a/mitxgraders/baseclasses.py
+++ b/mitxgraders/baseclasses.py
@@ -13,11 +13,12 @@ import abc
 import pprint
 import six
 import json
+from decimal import Decimal
 from voluptuous import Schema, Required, All, Any, Range, MultipleInvalid
 from voluptuous.humanize import validate_with_humanized_errors as voluptuous_validate
 from mitxgraders.version import __version__
 from mitxgraders.exceptions import ConfigError, MITxError, StudentFacingError
-from mitxgraders.helpers.validatorfuncs import text_string, Positive
+from mitxgraders.helpers.validatorfuncs import text_string, Positive, is_callable
 from mitxgraders.helpers.compatibility import ensure_text
 
 class DefaultValuesMeta(abc.ABCMeta):
@@ -175,22 +176,11 @@ class AbstractGrader(ObjectWithSchema):
         suppress_warnings (bool): Whether to suppress warnings that the given
             configuration may lead to unintended consequences (default False)
 
-        attempt_based_credit (bool): Whether to award different amounts of credit
-            based on the attempt number. Requires the attempt number to be passed to the
-            grader; see documentation. When using lists, only applies to the grader
-            that is passed through to edX. (default False)
-
-        decrease_credit_after (positive int): The last attempt number to award maximum
-            credit to (default 1)
-
-        minimum_credit (float between 0 and 1): The minimum amount of credit to be awarded
-            after using too many attempts (default 0.2)
-
-        decrease_credit_steps (positive int): How many attempts it takes to get to minimum
-            credit. So, if set to 1, after decrease_credit_after attempts, the next attempt
-            will receive minimum_credit. If set to 2, the next attempt will be halfway
-            between 1 and minimum_credit, and the attempt after that will be awarded
-            minimum_credit. (default 4)
+        attempt_based_credit (None | function): Function to specify maximum credit available
+            given the attempt number (function should be unary and return a number between
+            0 and 1 inclusive). Set to None to disable attempt-based partial credit. This
+            setting is applied to all inputs in the problem, and only needs to be set on
+            the grader that is passed through to edX. (default None)
 
         attempt_based_credit_msg (bool): When maximum credit has been decreased due to
             attempt number, present the student with a message explaining so (default True)
@@ -203,12 +193,9 @@ class AbstractGrader(ObjectWithSchema):
         Classes that inherit from AbstractGrader should extend this schema.
         """
         return Schema({
-            Required('debug', default=False): bool,  # Use to turn on debug output
+            Required('debug', default=False): bool,
             Required('suppress_warnings', default=False): bool,
-            Required('attempt_based_credit', default=False): bool,
-            Required('decrease_credit_after', default=1): Positive(int),
-            Required('decrease_credit_steps', default=4): Positive(int),
-            Required('minimum_credit', default=0.2): Any(All(float, Range(0, 1)), 0, 1),
+            Required('attempt_based_credit', default=None): Any(None, is_callable),
             Required('attempt_based_credit_msg', default=True): bool
         })
 
@@ -357,23 +344,18 @@ class AbstractGrader(ObjectWithSchema):
                    'The attribute <code>cfn_extra_args="attempt"</code> may need to be '
                    "set in the <code>customresponse</code> tag.")
             raise ConfigError(msg)
-        self.log("Attempt number {}".format(attempt_number))
 
-        # How far past the point of decreasing credit are we?
         if attempt_number < 1:  # Just in case edX has issues
             attempt_number = 1
-        steps = attempt_number - self.config['decrease_credit_after']
-        if steps <= 0:
-            return
+        self.log("Attempt number {}".format(attempt_number))
 
-        # Compute the credit to be awarded
-        min_cred = self.config['minimum_credit']
-        decrease_steps = self.config['decrease_credit_steps']
-        if steps >= decrease_steps:
-            credit = min_cred
-        else:
-            # Linear interpolation
-            credit = 1 + (min_cred - 1) * steps / decrease_steps
+        # Compute the maximum credit
+        credit = self.config['attempt_based_credit'](attempt_number)
+        credit = float(credit)  # In case graders return integers 0 or 1
+        credit = round(credit, 4)
+        if credit == 1:
+            # Don't do any modifications
+            return
         self.log("Maximum credit is {}".format(credit))
 
         # Multiply all grades by credit, updating from 'ok'=True to 'partial' as needed
@@ -394,14 +376,18 @@ class AbstractGrader(ObjectWithSchema):
 
         # Append the message if credit was reduced
         if self.config['attempt_based_credit_msg'] and changed_result:
-            msg = "Maximum credit for attempt #{} is {:04.2f}."
+            credit_decimal = Decimal(credit * 100).quantize(Decimal('.1'))
+            if credit_decimal == int(credit_decimal):
+                # Used to get rid of .0 appearing in percentages
+                credit_decimal = int(credit_decimal)
+            msg = "Maximum credit for attempt #{} is {}%."
             if "input_list" in result:
                 key = 'overall_message'
             else:
                 key = 'msg'
             if result[key]:
                 result[key] += '\n\n'
-            result[key] += msg.format(attempt_number, credit)
+            result[key] += msg.format(attempt_number, credit_decimal)
 
     @staticmethod
     def grade_decimal_to_ok(grade):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -532,7 +532,9 @@ def test_attempt_based_grading_single():
     expected_result = {'msg': 'Maximum credit for attempt #5 is 6.2%.', 'grade_decimal': 0.0625, 'ok': 'partial'}
     assert grader(None, 'cat', attempt=5) == expected_result
     expected_result = {'msg': 'Maximum credit for attempt #6 is 3.1%.', 'grade_decimal': 0.0313, 'ok': 'partial'}
-    assert grader(None, 'cat', attempt=6) == expected_result
+    assert grader(None, 'cat', attempt=6)['msg'] == expected_result['msg']
+    assert grader(None, 'cat', attempt=6)['ok'] == expected_result['ok']
+    assert grader(None, 'cat', attempt=6)['grade_decimal'] == approx(expected_result['grade_decimal'])
 
 def test_attempt_based_grading_list():
     grader = ListGrader(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -534,7 +534,7 @@ def test_attempt_based_grading_single():
     expected_result = {'msg': 'Maximum credit for attempt #6 is 3.1%.', 'grade_decimal': 0.0313, 'ok': 'partial'}
     assert grader(None, 'cat', attempt=6)['msg'] == expected_result['msg']
     assert grader(None, 'cat', attempt=6)['ok'] == expected_result['ok']
-    assert grader(None, 'cat', attempt=6)['grade_decimal'] == approx(expected_result['grade_decimal'])
+    assert abs(grader(None, 'cat', attempt=6)['grade_decimal'] - expected_result['grade_decimal']) <= 0.001
 
 def test_attempt_based_grading_list():
     grader = ListGrader(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,6 +12,7 @@ import mitxgraders
 from mitxgraders import ListGrader, StringGrader, ConfigError, FormulaGrader, __version__
 from mitxgraders.baseclasses import AbstractGrader, ItemGrader
 from mitxgraders.exceptions import MITxError, StudentFacingError
+from mitxgraders.attemptcredit import LinearCredit, GeometricCredit
 from tests.helpers import mock
 
 def test_debug_with_author_message():
@@ -355,10 +356,11 @@ def test_attempt_based_grading_single():
     # Test basic usage
     grader = StringGrader(
         answers='cat',
-        attempt_based_credit=True,
-        decrease_credit_after=3,
-        decrease_credit_steps=3,
-        minimum_credit=0.1,
+        attempt_based_credit=LinearCredit(
+            decrease_credit_after=3,
+            decrease_credit_steps=3,
+            minimum_credit=0.1
+        ),
         attempt_based_credit_msg=False
     )
 
@@ -386,7 +388,7 @@ def test_attempt_based_grading_single():
     # Ensure it turns off properly
     grader = StringGrader(
         answers='cat',
-        attempt_based_credit=False
+        attempt_based_credit=None
     )
 
     expected_result = {'msg': '', 'grade_decimal': 1, 'ok': True}
@@ -396,7 +398,7 @@ def test_attempt_based_grading_single():
     # Ensure that wrong answers are always zeros
     grader = StringGrader(
         answers='cat',
-        attempt_based_credit=True
+        attempt_based_credit=LinearCredit()
     )
 
     expected_result = {'msg': '', 'grade_decimal': 0, 'ok': False}
@@ -406,8 +408,7 @@ def test_attempt_based_grading_single():
     # Ensure that zero credit is graded as false appropriately
     grader = StringGrader(
         answers='cat',
-        attempt_based_credit=True,
-        minimum_credit=0,
+        attempt_based_credit=LinearCredit(minimum_credit=0),
         attempt_based_credit_msg=False
     )
 
@@ -418,10 +419,11 @@ def test_attempt_based_grading_single():
     # Ensure that messages are included as appropriate
     grader = StringGrader(
         answers='cat',
-        attempt_based_credit=True,
-        minimum_credit=0,
-        decrease_credit_after=1,
-        decrease_credit_steps=2,
+        attempt_based_credit=LinearCredit(
+            minimum_credit=0,
+            decrease_credit_after=1,
+            decrease_credit_steps=2
+        ),
         attempt_based_credit_msg=True
     )
 
@@ -430,12 +432,12 @@ def test_attempt_based_grading_single():
     expected_result = {'msg': '', 'grade_decimal': 0, 'ok': False}
     assert grader(None, 'dog', attempt=1) == expected_result
 
-    expected_result = {'msg': 'Maximum credit for attempt #2 is 0.50.', 'grade_decimal': 0.5, 'ok': 'partial'}
+    expected_result = {'msg': 'Maximum credit for attempt #2 is 50%.', 'grade_decimal': 0.5, 'ok': 'partial'}
     assert grader(None, 'cat', attempt=2) == expected_result
     expected_result = {'msg': '', 'grade_decimal': 0, 'ok': False}
     assert grader(None, 'dog', attempt=2) == expected_result
 
-    expected_result = {'msg': 'Maximum credit for attempt #3 is 0.00.', 'grade_decimal': 0, 'ok': False}
+    expected_result = {'msg': 'Maximum credit for attempt #3 is 0%.', 'grade_decimal': 0, 'ok': False}
     assert grader(None, 'cat', attempt=3) == expected_result
     expected_result = {'msg': '', 'grade_decimal': 0, 'ok': False}
     assert grader(None, 'dog', attempt=3) == expected_result
@@ -444,10 +446,11 @@ def test_attempt_based_grading_single():
     # Also test that reduced-value entries are affected by partial credit as expected
     grader = StringGrader(
         answers={'expect': 'cat', 'msg': 'Meow!', 'grade_decimal': 0.5},
-        attempt_based_credit=True,
-        minimum_credit=0,
-        decrease_credit_after=1,
-        decrease_credit_steps=2,
+        attempt_based_credit=LinearCredit(
+            minimum_credit=0,
+            decrease_credit_after=1,
+            decrease_credit_steps=2,
+        ),
         attempt_based_credit_msg=True,
         wrong_msg='too bad'
     )
@@ -457,12 +460,12 @@ def test_attempt_based_grading_single():
     expected_result = {'msg': 'too bad', 'grade_decimal': 0, 'ok': False}
     assert grader(None, 'dog', attempt=1) == expected_result
 
-    expected_result = {'msg': 'Meow!<br/>\n<br/>\nMaximum credit for attempt #2 is 0.50.', 'grade_decimal': 0.25, 'ok': 'partial'}
+    expected_result = {'msg': 'Meow!<br/>\n<br/>\nMaximum credit for attempt #2 is 50%.', 'grade_decimal': 0.25, 'ok': 'partial'}
     assert grader(None, 'cat', attempt=2) == expected_result
     expected_result = {'msg': 'too bad', 'grade_decimal': 0, 'ok': False}
     assert grader(None, 'dog', attempt=2) == expected_result
 
-    expected_result = {'msg': 'Meow!<br/>\n<br/>\nMaximum credit for attempt #3 is 0.00.', 'grade_decimal': 0, 'ok': False}
+    expected_result = {'msg': 'Meow!<br/>\n<br/>\nMaximum credit for attempt #3 is 0%.', 'grade_decimal': 0, 'ok': False}
     assert grader(None, 'cat', attempt=3) == expected_result
     expected_result = {'msg': 'too bad', 'grade_decimal': 0, 'ok': False}
     assert grader(None, 'dog', attempt=3) == expected_result
@@ -470,7 +473,7 @@ def test_attempt_based_grading_single():
     # Ensure that things behave when an attempt number is not passed in
     grader = StringGrader(
         answers='cat',
-        attempt_based_credit=True
+        attempt_based_credit=LinearCredit()
     )
 
     msg = ("Attempt number not passed to grader as keyword argument 'attempt'. "
@@ -482,7 +485,7 @@ def test_attempt_based_grading_single():
     # Ensure that debug info is passed along
     grader = StringGrader(
         answers='cat',
-        attempt_based_credit=True,
+        attempt_based_credit=LinearCredit(),
         debug=True
     )
 
@@ -499,7 +502,7 @@ def test_attempt_based_grading_single():
     expected_result = {'msg': msg, 'grade_decimal': 1, 'ok': True}
     assert grader(None, 'cat', attempt=1) == expected_result
 
-    template = ("Maximum credit for attempt #3 is 0.60.\n\n<pre>"
+    template = ("Maximum credit for attempt #3 is 60%.\n\n<pre>"
                 "MITx Grading Library Version {version}\n"
                 "{debug_content}\n"
                 "{attempt_msg}"
@@ -511,11 +514,31 @@ def test_attempt_based_grading_single():
     expected_result = {'msg': msg, 'grade_decimal': 0.6, 'ok': 'partial'}
     assert grader(None, 'cat', attempt=3) == expected_result
 
+    # Ensure that percentages round nicely
+    grader = StringGrader(
+        answers='cat',
+        attempt_based_credit=GeometricCredit(factor=0.5),
+        attempt_based_credit_msg=True
+    )
+
+    expected_result = {'msg': '', 'grade_decimal': 1, 'ok': True}
+    assert grader(None, 'cat', attempt=1) == expected_result
+    expected_result = {'msg': 'Maximum credit for attempt #2 is 50%.', 'grade_decimal': 0.5, 'ok': 'partial'}
+    assert grader(None, 'cat', attempt=2) == expected_result
+    expected_result = {'msg': 'Maximum credit for attempt #3 is 25%.', 'grade_decimal': 0.25, 'ok': 'partial'}
+    assert grader(None, 'cat', attempt=3) == expected_result
+    expected_result = {'msg': 'Maximum credit for attempt #4 is 12.5%.', 'grade_decimal': 0.125, 'ok': 'partial'}
+    assert grader(None, 'cat', attempt=4) == expected_result
+    expected_result = {'msg': 'Maximum credit for attempt #5 is 6.2%.', 'grade_decimal': 0.0625, 'ok': 'partial'}
+    assert grader(None, 'cat', attempt=5) == expected_result
+    expected_result = {'msg': 'Maximum credit for attempt #6 is 3.1%.', 'grade_decimal': 0.0313, 'ok': 'partial'}
+    assert grader(None, 'cat', attempt=6) == expected_result
+
 def test_attempt_based_grading_list():
     grader = ListGrader(
         answers=['cat', 'dog'],
         subgraders=StringGrader(),
-        attempt_based_credit=True,
+        attempt_based_credit=LinearCredit(),
     )
 
     expected_result = {
@@ -528,7 +551,7 @@ def test_attempt_based_grading_list():
     assert grader(None, ['cat', 'dog'], attempt=1) == expected_result
 
     expected_result = {
-        'overall_message': 'Maximum credit for attempt #5 is 0.20.',
+        'overall_message': 'Maximum credit for attempt #5 is 20%.',
         'input_list': [
             {'ok': 'partial', 'grade_decimal': 0.2, 'msg': ''},
             {'ok': 'partial', 'grade_decimal': 0.2, 'msg': ''}
@@ -537,7 +560,7 @@ def test_attempt_based_grading_list():
     assert grader(None, ['cat', 'dog'], attempt=5) == expected_result
 
     expected_result = {
-        'overall_message': 'Maximum credit for attempt #5 is 0.20.',
+        'overall_message': 'Maximum credit for attempt #5 is 20%.',
         'input_list': [
             {'ok': 'partial', 'grade_decimal': 0.2, 'msg': ''},
             {'ok': False, 'grade_decimal': 0, 'msg': ''}


### PR DESCRIPTION
This overhauls attempt-based partial credit. I think it's an improvement over the API I previously implemented, as it allows for maximum flexibility, while useful defaults are provided.