### PR TITLE
Allow SingleListGrader answers to be specified as a string

### DIFF
--- a/course/problem/singlelist3.xml
+++ b/course/problem/singlelist3.xml
@@ -2,12 +2,14 @@
 
 <p>By default, the grader accepts any number of inputs in the list (try it in some of the other examples!). If you want to raise an error if the number of inputs is wrong, then you can do that too.</p>
 
-<p>In 3D, what are the components of the \(\hat{y}\) unit vector? (Answer: 0, 1, 0). Try putting in two or four components instead of three. Also note that this input is ordered. (Note that you should probably use the <code>MatrixGrader</code> for this question instead of a <code>SingleListGrader</code>!)</p>
+<p>In 3D, what are the components of the \(\hat{y}\) unit vector? (Answer: <code>0, 1, 0</code>). Try putting in two or four components instead of three. Also note that this input is ordered. (Note that you should probably use the <code>MatrixGrader</code> for this question instead of a <code>SingleListGrader</code>!)</p>
+
+<p>This example also demonstrates how you can provide a string for the answers key, rather than a list.</p>
 
 <script type="text/python">
 from mitxgraders import *
 grader = SingleListGrader(
-    answers=['0', '1', '0'],
+    answers="0, 1, 0",
     subgrader=FormulaGrader(),
     length_error=True,
     ordered=True

--- a/docs/edx.md
+++ b/docs/edx.md
@@ -64,7 +64,7 @@ Also worth noting is that the grader is stored in a python variable, which in th
 
 ## Using `correct_answer` for multiple inputs
 
-If you are using multiple inputs (such as when using a `ListGrader`) or a `SingleListGrader`, you must provide the `answers` key to the grader explicitly, as the `expect` or `answer` parameters in the `customresponse` tag are ignored by both edX and the grader. When using multiple inputs, it's recommended to provide a `correct_answer` parameter on the `textline` tags, which is what is used to show students the correct answer. Here is an example.
+If you are using multiple inputs (such as when using a `ListGrader`), you must provide the `answers` key to the grader explicitly, as the `expect` or `answer` parameters in the `customresponse` tag are ignored by both edX and the grader. When using multiple inputs, it's recommended to provide a `correct_answer` parameter on the `textline` tags, which is what is used to show students the correct answer. Here is an example.
 
 ```XML
 <problem>

--- a/docs/grading_lists/single_list_grader.md
+++ b/docs/grading_lists/single_list_grader.md
@@ -65,6 +65,26 @@ True
 
 Note that the list of answers can itself occur inside a dictionary that has a grade and message associated with it. In this case, the answers are evaluated as normal, and the overall grade is multiplied by `grade_decimal`. The message is only shown if all of the inputs received credit. So, note that `feline, anything` will get the "Good enough!" message, while the "something strange" message only appears if the student enters both `unicorn` and `lumberjack`.
 
+As a convenience, you can also provide an answer that is just a string, corresponding to what students would enter. Beware that spaces included after delimiters will be included in the following entry.
+
+```pycon
+>>> from mitxgraders import *
+>>> grader = SingleListGrader(
+...     answers='cat, dog',
+...     subgrader=StringGrader()
+... )
+>>> grader(None, 'cat, dog') == {'grade_decimal': 1.0, 'msg': '', 'ok': True}
+True
+>>> grader(None, 'dog, cat') == {'grade_decimal': 1.0, 'msg': '', 'ok': True}
+True
+>>> grader(None, 'cat, octopus') == {'grade_decimal': 0.5, 'msg': '', 'ok': 'partial'}
+True
+
+```
+
+This means that `SingleListGrader`s are capable of inferring answers from the `expect` keyword of a `customresponse` tag.
+
+
 
 ## Messages
 

--- a/mitxgraders/listgrader.py
+++ b/mitxgraders/listgrader.py
@@ -677,7 +677,14 @@ class SingleListGrader(ItemGrader):
         """
         # The structure of answer_tuple at this stage is:
         # tuple(dict('expect', 'grade_decimal', 'ok', 'msg'))
-        # where 'expect' is a list that needs validation.
+        # where 'expect' needs validation.
+
+        # Step 1: If 'expect' is a string, use infer_from_expect to convert it to a list.
+        for entry in answer_tuple:
+            if isinstance(entry['expect'], six.string_types):
+                entry['expect'] = self.infer_from_expect(entry['expect'])
+        # Redo schema validation to validate any modified answers
+        answer_tuple = self.schema_answers(answer_tuple)
 
         # Check that all lists in the tuple have the same length
         for answer_list in answer_tuple:
@@ -705,9 +712,12 @@ class SingleListGrader(ItemGrader):
     @staticmethod
     def validate_expect(expect):
         """
-        Defines the schema that answers should satisfy. For SingleListGrader, this is a list.
+        Defines the schema that answers should satisfy.
+
+        This should be either a list or a string. If a string is provided,
+        it will be split into a list.
         """
-        return Schema(list)(expect)
+        return Schema(Any(list, str))(expect)
 
     def check_response(self, answer, student_input, **kwargs):
         """Check student_input against a given answer list"""

--- a/mitxgraders/listgrader.py
+++ b/mitxgraders/listgrader.py
@@ -715,9 +715,9 @@ class SingleListGrader(ItemGrader):
         Defines the schema that answers should satisfy.
 
         This should be either a list or a string. If a string is provided,
-        it will be split into a list.
+        it will be split into a list by post_schema_ans_val.
         """
-        return Schema(Any(list, str))(expect)
+        return Schema(Any(list, text_string))(expect)
 
     def check_response(self, answer, student_input, **kwargs):
         """Check student_input against a given answer list"""

--- a/tests/test_singlelistgrader.py
+++ b/tests/test_singlelistgrader.py
@@ -565,3 +565,40 @@ def test_overall_msg_nested():
     result = grader(None, 'a,b;c,e')
     assert result['grade_decimal'] == 0.75
     assert result['msg'] == ''
+
+def test_string_answers():
+    sg = StringGrader()
+
+    grader1 = SingleListGrader(
+        answers="an,apple",
+        subgrader=sg
+    )
+    grader2 = SingleListGrader(
+        answers=["an", "apple"],
+        subgrader=sg
+    )
+    assert(grader1 == grader2)
+
+    grader1 = SingleListGrader(
+        answers="this,is;a,test",
+        subgrader=SingleListGrader(subgrader=sg),
+        delimiter=";"
+    )
+    grader2 = SingleListGrader(
+        answers=[["this", "is"], ["a", "test"]],
+        subgrader=SingleListGrader(subgrader=sg),
+        delimiter=";"
+    )
+    assert(grader1 == grader2)
+
+    fg = FormulaGrader(variables=['x'])
+
+    grader1 = SingleListGrader(
+        answers="1+x,2*x^2",
+        subgrader=fg
+    )
+    grader2 = SingleListGrader(
+        answers=["1+x", "2*x^2"],
+        subgrader=fg
+    )
+    assert(grader1 == grader2)


### PR DESCRIPTION
This is useful when providing grade_decimal or msg entries in answers, as it means you don't need to construct a list of individual entries, but rather just specify the string that is expected from students.