### PR TITLE
Adding allow_inf flag to FormulaGrader

### DIFF
--- a/docs/grading_math/formula_grader.md
+++ b/docs/grading_math/formula_grader.md
@@ -122,6 +122,34 @@ By default, four constants are defined: `e`, `pi`, and `i=j=sqrt(-1)`. You can d
 Constants are treated as variables that only ever have one value.
 
 
+### Infinities
+
+When an expression results in an infinity, students are presented with an error message asking them to check for overflow. If you actually want infinity to be an acceptable answer, then you can specify `allow_inf=True`. This allows expressions to evaluate to infinity (or negative infinity), and also makes the constant `infty` available for students to use.
+
+```pycon
+>>> # Without allow_inf turned on:
+>>> grader = FormulaGrader(
+...     answers='infty',
+...     user_constants={
+...         'infty': float('inf')
+...     }
+... )
+>>> try:
+...     grader(None, 'infty')
+... except CalcError as error:
+...     print(error)
+Numerical overflow occurred. Does your expression generate very large numbers?
+>>> # With allow_inf turned on:
+>>> grader = FormulaGrader(
+...     answers='infty',
+...     allow_inf=True
+... )
+>>> grader(None, 'infty') == {'ok': True, 'msg': '', 'grade_decimal': 1}
+True
+
+```
+
+
 ## Functions
 
 By default, a large array of mathematical functions are available for use. See the full list [here](functions_and_constants.md). Note that all functions are capable of handling complex expressions unless otherwise stated. In the following example, `z*z` is recognized to be different from `abs(z)^2`.

--- a/docs/grading_math/matrix_grader/matrix_grader.md
+++ b/docs/grading_math/matrix_grader/matrix_grader.md
@@ -424,7 +424,7 @@ See the documentation for `MatrixEntryComparer` for details on how these options
 
 ## Configuration Options
 
-`MatrixGrader` has all of [`FormulaGrader`](../formula_grader.md)'s configuration options, plus some extras. The extras are:
+`MatrixGrader` has almost all of [`FormulaGrader`](../formula_grader.md)'s configuration options, plus some extras. The extras are:
 
 - `identity_dim`: If specified as a positive integer `n`, then an n by n identity matrix is added to the available constants with name `'I'`. Defaults to `None`.
 - `max_array_dim` (nonnegative int): Controls the maximum [dimension](#dimension-and-shape) of arrays that students can enter entry-by-entry. Default is `1`: vectors can be entered entry-by-entry, but not matrices.
@@ -438,3 +438,7 @@ See the documentation for `MatrixEntryComparer` for details on how these options
 
 - `entry_partial_credit`: If set to `proportional` or a number, uses this setting with `MatrixEntryComparer` as the default comparer.
 - `entry_partial_msg`: If set to a text value, uses this setting with `MatrixEntryComparer` as the default comparer.
+
+The `FormulaGrader` configuration keys that `MatrixGrader` does not have are:
+
+- `allow_inf`: We are unable to handle infinities appearing in vectors/matrices.

--- a/mitxgraders/formulagrader/matrixgrader.py
+++ b/mitxgraders/formulagrader/matrixgrader.py
@@ -97,7 +97,8 @@ class MatrixGrader(FormulaGrader):
                 Required('msg_detail', default='type'): Any(None, 'type', 'shape')
             },
             Optional('entry_partial_credit'): Any(All(Number, Range(0, 1)), 'proportional'),
-            Optional('entry_partial_msg'): text_string
+            Optional('entry_partial_msg'): text_string,
+            Required('allow_inf', default=False): False,  # Ensure that this is turned off
         })
 
     def __init__(self, config=None, **kwargs):

--- a/mitxgraders/helpers/calc/mathfuncs.py
+++ b/mitxgraders/helpers/calc/mathfuncs.py
@@ -15,6 +15,7 @@ Defines:
 from __future__ import print_function, division, absolute_import, unicode_literals
 
 import six
+from numbers import Number
 import numpy as np
 import scipy.special as special
 from mitxgraders.helpers.calc.specify_domain import SpecifyDomain
@@ -421,7 +422,29 @@ def within_tolerance(x, y, tolerance):
     0.223607
     >>> within_tolerance(A, B, 0.25)
     True
+
+    Also works for infinities (ignores tolerance in this case)
+    >>> inf = float('inf')
+    >>> within_tolerance(inf, inf, 0)
+    True
+    >>> within_tolerance(-inf, -inf, 0)
+    True
+    >>> within_tolerance(inf, -inf, 0)
+    False
+    >>> within_tolerance(1, inf, '100%')
+    False
+    >>> within_tolerance(inf, 1, '100%')
+    False
+
+    However, cannot handle infinities in matrices.
     """
+    # Handle infinities separately, ignoring any tolerance
+    # Only do this for numbers, not matrices
+    inf = float('inf')
+    if isinstance(x, Number):
+        if x == inf or y == inf or x == -inf or y == -inf:
+            return x == y
+
     # When used within graders, tolerance has already been
     # validated as a Number or PercentageString
     if isinstance(tolerance, six.text_type):

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -966,3 +966,20 @@ def test_dependentsampler():
     )
     assert grader(None, 'y')['ok']
     assert grader(None, 'x^2')['ok']
+
+def test_infinity():
+    grader = FormulaGrader(
+        answers="infty",
+        allow_inf=True
+    )
+    assert grader(None, 'infty')['ok']
+    assert not grader(None, '-infty')['ok']
+    assert grader.default_variables['infty'] == float('inf')
+
+    grader = FormulaGrader(
+        answers='infty',
+        user_constants={'infty': float('inf')}
+    )
+    assert 'infty' not in grader.default_variables
+    with raises(CalcError, match='Numerical overflow occurred. Does your expression generate very large numbers?'):
+        grader(None, 'infty')


### PR DESCRIPTION
Introduces a flag to allow infinities to appear in FormulaGrader expressions (but not matrix expressions).