### PR TITLE
Input sanitizing, parsing emdash as minus sign, adds some tests for that.

### DIFF
--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -387,7 +387,12 @@ class MathParser(object):
 
         # Define + and -
         plus = Literal("+")
-        minus = Literal("-")
+
+        # Also accept unicode emdash
+        emdash = Literal("\u2014") 
+        emdash.setParseAction(lambda: "-")
+        
+        minus = Literal("-") | emdash
         plus_minus = plus | minus
 
         # 1 or 1.0 or .1

--- a/tests/helpers/calc/test_expressions.py
+++ b/tests/helpers/calc/test_expressions.py
@@ -1,7 +1,7 @@
 """
 Tests of expressions.py that aren't covered elsewhere
 """
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import re
 import numpy as np
@@ -147,6 +147,35 @@ def test_negation():
         with raises(UnableToParse, match=re.escape(msg.format(formula))):
             evaluator(formula)
 
+
+def test_negation_with_emdash():
+    """Test that appropriate numbers of +/emdash signs are accepted"""
+    assert evaluator(u"1+\u20141")[0] == 0
+    assert evaluator("1\u2014\u20141")[0] == 2
+    assert evaluator("2*\u20141")[0] == -2
+    assert evaluator("2/\u20144")[0] == -0.5
+    assert evaluator("\u20141+\u20141")[0] == -2
+    assert evaluator("+1+\u20141")[0] == 0
+    assert evaluator("2^\u20142")[0] == 0.25
+    assert evaluator("+\u20141")[0] == -1
+
+    badformulas = [
+        "1\u2014\u2014\u20141",
+        "2^\u2014\u20142",
+        "1\u2014+2",
+        "1++2",
+        "1+++2",
+        "\u2014\u20142",
+        "\u2014\u2014\u20142",
+        "\u2014+2",
+        "\u2014\u2014+2",
+    ]
+
+    msg = "Invalid Input: Could not parse '{}' as a formula"
+    for formula in badformulas:
+        with raises(UnableToParse, match=re.escape(msg.format(formula))):
+            evaluator(formula)
+            
 def test_evaluation_does_not_mutate_variables():
     """
     This test should not be considered as related to vector/matrix/tensor algebra.


### PR DESCRIPTION
Hi!  Someone reported an issue when pasting some math into an input field on edx.  Some confusion arose around a unicode look-a-like character that looks like a dash, but is, in fact an emdash!  Here they are:

`emdash: –` 
`dash..:      -`

The problem was that the mitx-grading-library parser was expecting an ascii dash but instead got an emdash.  So, the user got a syntax error.  This commit fixes that problem by adding a rule that tokenizes emdashes and immediately converts them to ascii dashes.