### PR TITLE
Implementing functionality to remove default math constants

### DIFF
--- a/docs/grading_math/formula_grader.md
+++ b/docs/grading_math/formula_grader.md
@@ -121,6 +121,19 @@ By default, four constants are defined: `e`, `pi`, and `i=j=sqrt(-1)`. You can d
 
 Constants are treated as variables that only ever have one value.
 
+If you want to remove a default constant, you can do so by setting it to `None`:
+
+```pycon
+>>> grader = FormulaGrader(
+...     answers='sqrt(-1)',
+...     user_constants={
+...         'i': None,
+...         'j': None
+...     }
+... )
+
+```
+
 
 ### Infinities
 

--- a/mitxgraders/helpers/math_helpers.py
+++ b/mitxgraders/helpers/math_helpers.py
@@ -440,6 +440,16 @@ class MathMixin(object):
                                             self.config['blacklist'],
                                             self.config['whitelist'])
         
+        # Make a copy of self.default_variables, so we don't change the base version
+        self.default_variables = self.default_variables.copy()
+        
+        # Remove any deleted user constants from self.default_variables
+        remove_keys = [key for key in self.config['user_constants'] if self.config['user_constants'][key] is None]
+        for entry in remove_keys:
+            if entry in self.default_variables:
+                del self.default_variables[entry]
+            del self.config['user_constants'][entry]
+        
         warn_if_override(self.config, 'variables', self.default_variables)
         warn_if_override(self.config, 'numbered_vars', self.default_variables)
         warn_if_override(self.config, 'user_constants', self.default_variables)

--- a/mitxgraders/sampling.py
+++ b/mitxgraders/sampling.py
@@ -602,9 +602,9 @@ def construct_functions(default_functions, user_funcs):
 
 def validate_user_constants(*allow_types):
     return All(
-        has_keys_of_type(six.string_types),
-        coerce_string_keys_to_text_type,
-        {Extra: Any(*allow_types)},
+            has_keys_of_type(six.string_types),
+            coerce_string_keys_to_text_type,
+            {Extra: Any(Any(*allow_types), None)}
     )
 
 def construct_constants(default_variables, user_consts):

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -251,6 +251,32 @@ def test_fg_userconstants():
             answers="1",
             user_constants={1: 5}
         )
+        
+    # Test collisions
+    with raises(ConfigError, match='will override default values'):
+        grader = FormulaGrader(
+            answers="5",
+            user_constants={"i": 5}
+        )
+    
+    # Test removals
+    grader = FormulaGrader(
+        answers="5",
+        user_constants={"i": None}
+    )
+    with raises(UndefinedVariable, match="'i' not permitted"):
+        grader(None, 'i')
+
+    grader = FormulaGrader(
+        answers="-1"
+    )
+    assert grader(None, "i^2")['ok']
+    grader = FormulaGrader(
+        answers="-1",
+        user_constants={"i": None},
+        variables=['i']
+    )
+    assert not grader(None, "i^2")['ok']
 
 def test_fg_blacklist_grading():
     """Test FormulaGrader with blacklists and whitelists"""


### PR DESCRIPTION
This allows an instructor to set a pre-defined constant to `None` to remove it from the list of constants.