### PR TITLE
Implementing tuple options for expect values

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Unit Tests
 on: [push]
 jobs:
   Python-3-Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7]
@@ -28,7 +28,7 @@ jobs:
         run: codecov
 
   Python-2-Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [2.7]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,6 +43,10 @@ This is a major new version with many new features added. We have been very care
 
 ## Version 2.1
 
+### Version 2.1.1
+
+* Fixed a bug in LinearComparer when a student's answer was constant.
+
 ### Version 2.1.0
 
 * Added a new grader `IntervalGrader`, which grades expressions for mathematical intervals.

--- a/docs/item_grader.md
+++ b/docs/item_grader.md
@@ -32,7 +32,7 @@ For all `ItemGrader`s, the `answers` key can be used to specify correct answers,
 
 - A single dictionary can be used to specify an answer, feedback, correctness, and partial credit. The dictionary keys are:
 
-    - `'expect'` (required): compared against student answer. Most `ItemGrader`s use strings to specify the `'expect'` value.
+    - `'expect'` (required): compared against student answer. Most `ItemGrader`s use strings to specify the `'expect'` value. You may also specify a tuple of values like `('option1', 'option2')` if you want the same grade and message applied to all these inputs.
     - `'grade_decimal'` (optional, a number between `0` and `1` inclusive): The credit associated with this answer (default `1`).
     - `'msg'` (optional, string): An optional feedback message associated with this answer (default `''`).
 
@@ -78,7 +78,9 @@ True
 ...         # a partially correct answer
 ...         {'expect': 'dog', 'grade_decimal': 0.5, 'msg': 'No, not dog!'},
 ...         # a wrong answer with specific feedback
-...         {'expect': 'unicorn', 'grade_decimal': 0, 'msg': 'No, not unicorn!'}
+...         {'expect': 'unicorn', 'grade_decimal': 0, 'msg': 'No, not unicorn!'},
+...         # multiple wrong answers with specific feedback
+...         {'expect': ('werewolf', 'vampire'), 'grade_decimal': 0, 'msg': 'Wrong universe!'}
 ...     ),
 ...     wrong_msg='Try again!'
 ... )
@@ -90,9 +92,12 @@ True
 True
 >>> grader(None, 'unicorn') == {'grade_decimal': 0, 'msg': 'No, not unicorn!', 'ok': False}
 True
+>>> grader(None, 'werewolf') == {'grade_decimal': 0, 'msg': 'Wrong universe!', 'ok': False}
+True
+>>> grader(None, 'vampire') == {'grade_decimal': 0, 'msg': 'Wrong universe!', 'ok': False}
+True
 >>> grader(None, 'cat') == {'grade_decimal': 0, 'msg': 'Try again!', 'ok': False}
 True
-
 ```
 
 Internally, the `ItemGrader` converts the answers entry into a tuple of dictionaries. When grading, it asks the specific grading class to grade the response against each possible answer, and selects the best outcome for the student.

--- a/docs/item_grader.md
+++ b/docs/item_grader.md
@@ -98,6 +98,7 @@ True
 True
 >>> grader(None, 'cat') == {'grade_decimal': 0, 'msg': 'Try again!', 'ok': False}
 True
+
 ```
 
 Internally, the `ItemGrader` converts the answers entry into a tuple of dictionaries. When grading, it asks the specific grading class to grade the response against each possible answer, and selects the best outcome for the student.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = --doctest-modules --cov=mitxgraders --cov-report=term-missing --doctest-glob='*.md' --no-cov
+addopts = --doctest-modules --cov=mitxgraders --cov-report=term-missing --doctest-glob='*.md'
 testpaths = tests mitxgraders docs
 doctest_optionflags = ALLOW_UNICODE

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = --doctest-modules --cov=mitxgraders --cov-report=term-missing --doctest-glob='*.md'
+addopts = --doctest-modules --cov=mitxgraders --cov-report=term-missing --doctest-glob='*.md' --no-cov
 testpaths = tests mitxgraders docs
 doctest_optionflags = ALLOW_UNICODE

--- a/tests/formulagrader/test_formulagrader.py
+++ b/tests/formulagrader/test_formulagrader.py
@@ -497,7 +497,7 @@ def test_fg_config_expect():
 
     # If trying to use comparer, a detailed validation error is raised
     expect = ("to have 3 arguments, instead it has 2 for dictionary value @ "
-              r"data\[u?'answers'\]\[0\]\[u?'expect'\]\[u?'comparer'\]")
+              r"data\[u?'answers'\]\[0\]\[u?'expect'\]\[0\]\[u?'comparer'\]")
     with raises(Error, match=expect):
         FormulaGrader(
             answers={
@@ -987,9 +987,9 @@ def test_default_comparer():
     FormulaGrader.reset_default_comparer()
     grader = FormulaGrader(answers='pi')
 
-    silly_grader.config['answers'][0]['expect']['comparer'] is silly_comparer
+    silly_grader.config['answers'][0]['expect'][0]['comparer'] is silly_comparer
     assert silly_grader(None, '1')['ok']
-    grader.config['answers'][0]['expect']['comparer'] is equality_comparer
+    grader.config['answers'][0]['expect'][0]['comparer'] is equality_comparer
     assert not grader(None, '1')['ok']
     assert grader(None, '3.141592653')['ok']
 

--- a/tests/formulagrader/test_intervalgrader.py
+++ b/tests/formulagrader/test_intervalgrader.py
@@ -87,6 +87,13 @@ def test_inferring_answers():
     assert grader("(1,2]", "(1,2]") == grader1("(1,2]", "(1,2]")
     assert grader("(1,2]", "(1,2)") == grader1("(1,2]", "(1,2)")
 
+def test_multiple_answers():
+    grader = IntervalGrader(answers={'expect': ("(1,2]", '(3,4]')})
+
+    expected_result = {'ok': True, 'grade_decimal': 1, 'msg': ''}
+    assert grader(None, "(1,2]") == expected_result
+    assert grader(None, "(3,4]") == expected_result
+
 def test_formulas():
     grader = IntervalGrader(
         answers="(x, y^2 + 1)",

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -87,8 +87,8 @@ def test_debug_with_input_list():
 
 def test_config():
     """Test giving a class a config dict or arguments"""
-    assert StringGrader(answers="cat").config["answers"][0]['expect'] == "cat"
-    assert StringGrader({'answers': 'cat'}).config["answers"][0]['expect'] == "cat"
+    assert StringGrader(answers="cat").config["answers"][0]['expect'][0] == "cat"
+    assert StringGrader({'answers': 'cat'}).config["answers"][0]['expect'][0] == "cat"
 
 def test_itemgrader():
     """Various tests of ItemGrader. We use StringGrader as a standin for ItemGrader"""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -245,7 +245,9 @@ def test_docs():
             # a partially correct answer
             {'expect': 'dog', 'grade_decimal': 0.5, 'msg': 'No, not dog!'},
             # a wrong answer with specific feedback
-            {'expect': 'unicorn', 'grade_decimal': 0, 'msg': 'No, not unicorn!'}
+            {'expect': 'unicorn', 'grade_decimal': 0, 'msg': 'No, not unicorn!'},
+            # multiple wrong answers with specific feedback
+            {'expect': ('werewolf', 'vampire'), 'grade_decimal': 0, 'msg': 'Wrong universe!'}
         ),
         wrong_msg='Try again!'
     )
@@ -256,6 +258,11 @@ def test_docs():
     assert grader(None, 'dog') == expected_result
     expected_result = {'msg': 'No, not unicorn!', 'grade_decimal': 0, 'ok': False}
     assert grader(None, 'unicorn') == expected_result
+    expected_result = {'msg': 'Wrong universe!', 'grade_decimal': 0, 'ok': False}
+    assert grader(None, 'werewolf') == expected_result
+    assert grader(None, 'vampire') == expected_result
+    expected_result = {'msg': 'Try again!', 'grade_decimal': 0, 'ok': False}
+    assert grader(None, 'other') == expected_result
 
 def test_readme():
     """Tests that the README.md file examples work"""

--- a/tests/test_singlelistgrader.py
+++ b/tests/test_singlelistgrader.py
@@ -486,10 +486,10 @@ def test_answer_validation():
     )
     assert grader.config['answers'] == (
         {
-            'expect': [
-                ({'expect': 'a', 'msg': '', 'grade_decimal': 1, 'ok': True}, ),
-                ({'expect': 'b', 'msg': '', 'grade_decimal': 1, 'ok': True}, )
-            ],
+            'expect': ([
+                ({'expect': ('a', ), 'msg': '', 'grade_decimal': 1, 'ok': True}, ),
+                ({'expect': ('b', ), 'msg': '', 'grade_decimal': 1, 'ok': True}, )
+            ], ),
             'grade_decimal': 1,
             'msg': '',
             'ok': True

--- a/tests/test_singlelistgrader.py
+++ b/tests/test_singlelistgrader.py
@@ -548,6 +548,30 @@ def test_overall_grade_msg():
     assert result['grade_decimal'] == 0.25
     assert result['msg'] == ''
 
+def test_multiple_answers():
+    grader = SingleListGrader(
+        subgrader=StringGrader(),
+        answers={'expect': ['a', ('b', 'c')], 'msg': 'Yay', 'grade_decimal': 0.5}
+    )
+    assert grader(None, 'a, b')['grade_decimal'] == 0.5
+    assert grader(None, 'a, b')['msg'] == 'Yay'
+    assert grader(None, 'a, c')['grade_decimal'] == 0.5
+    assert grader(None, 'a, c')['msg'] == 'Yay'
+    assert grader(None, 'a, d')['grade_decimal'] == 0.25
+    assert grader(None, 'a, d')['msg'] == ''
+
+    grader = SingleListGrader(
+        subgrader=StringGrader(),
+        answers={'expect': (['a', 'b'], ['c', 'a']), 'msg': 'Yay', 'grade_decimal': 0.5},
+        ordered=True
+    )
+    assert grader(None, 'a, b')['grade_decimal'] == 0.5
+    assert grader(None, 'a, b')['msg'] == 'Yay'
+    assert grader(None, 'c, a')['grade_decimal'] == 0.5
+    assert grader(None, 'c, a')['msg'] == 'Yay'
+    assert grader(None, 'b, a')['grade_decimal'] == 0.25
+    assert grader(None, 'b, a')['msg'] == ''
+
 def test_overall_msg_nested():
     grader = SingleListGrader(
         answers={


### PR DESCRIPTION
Addresses #282 by allowing expect values to consist of a tuple of options.

The modifications to `ItemGrader` were pretty straightforward; propagating these changes to `post_schema_ans_val` was a little messy.

This is a work in progress: this needs extensive tests and documentation.